### PR TITLE
Added Hennepin handling to remove two scripts

### DIFF
--- a/Script Files/MEMOS/MEMOS - MAIN MENU.vbs
+++ b/Script Files/MEMOS/MEMOS - MAIN MENU.vbs
@@ -54,6 +54,12 @@ If buttonpressed = cancel then stopscript
 'Connecting to BlueZone
 EMConnect ""
 
+'Hennepin handling (they don't use the Appt Letter or NOMI scripts because they have permission (at least temporarily) to schedule using a time range instead of a single time. Because of this, the NOMI and Appt letter scripts would technically cause incorrect information to be sent to the clients. This is a simple solution until their procedures are updated.)
+If ucase(worker_county_code) = "X127" then
+	IF ButtonPressed = APPOINTMENT_LETTER_button 	THEN script_end_procedure("The Appointment Letter script is not available to Hennepin users at this time. Contact an alpha user or your supervisor if you have questions.")
+	IF ButtonPressed = NOMI_button 					THEN script_end_procedure("The NOMI script is not available to Hennepin users at this time. Contact an alpha user or your supervisor if you have questions.")
+End if
+
 IF ButtonPressed = TWELVE_MONTH_CONTACT_button 	THEN CALL run_from_GitHub(script_repository & "MEMOS/MEMOS - 12 MONTH CONTACT.vbs")
 IF ButtonPressed = APPOINTMENT_LETTER_button 	THEN CALL run_from_GitHub(script_repository & "MEMOS/MEMOS - APPOINTMENT LETTER.vbs")
 IF ButtonPressed = LTC_ASSET_TRANSFER_button 	THEN CALL run_from_GitHub(script_repository & "MEMOS/MEMOS - LTC - ASSET TRANSFER.vbs")


### PR DESCRIPTION
Because Hennepin is (at least temporarily) scheduling appointments in a
time-range (instead of a specific time), and they (at least temporarily)
have permission to do this, the NOMI and Appointment Letter scripts
might technically provide incorrect notice to clients, which could
create policy errors. So, I am temporarily removing access to them from
Hennepin users. If Hennepin is to use this same method in the near
future, separate versions of these two scripts may be deployed to allow
for a range of times.