### PR TITLE
Cs disregard fiater now with extra strength documentation

### DIFF
--- a/Script Files/ACTIONS/ACTIONS - CS DISREGARD FIAT.vbs
+++ b/Script Files/ACTIONS/ACTIONS - CS DISREGARD FIAT.vbs
@@ -386,8 +386,8 @@ ELSEIF MFIP_cash_status <> "" Then
 							'...the script subtracts the amount previously applied from this person...
 							applied_mfip_disregard = applied_mfip_disregard - Household_array(i, 6)
 							'...and applies the difference of the previous applied amount and the limit...	
-							MsgBox "The script is applying " & Household_array(i, 6) & " toward the disregard"  & vbCr & vbCr & "Press OK to continue."
 							Household_array(i, 6) = disregard_limit - applied_mfip_disregard
+							MsgBox "The script is applying " & Household_array(i, 6) & " toward the disregard"  & vbCr & vbCr & "Press OK to continue."
 						END IF
 						EMWriteScreen Household_array(i, 6), 21, 44
 						transmit


### PR DESCRIPTION
The script now has documentation.
The script is now able to ignore clients receiving SSI.
The script has MsgBoxes hardcoded at various points to notify the workers what the script is doing (feel free to remove).
*The msgboxes are at the point when the script is pulling CS income, when the script is determining the number of eligible children, and how much the script is applying.