### PR TITLE
SSA agreement fix

### DIFF
--- a/Script Files/ACTIONS/ACTIONS - SEND SVES.vbs
+++ b/Script Files/ACTIONS/ACTIONS - SEND SVES.vbs
@@ -104,7 +104,7 @@ If SSN_radiobutton = 1 then
   call navigate_to_screen("infc", "sves")
   'checking for IRS non-disclosure agreement.
   EMReadScreen agreement_check, 9, 2, 24
-  IF agreement_check = "Automated" THEN script_end_procedure(To view INFC data you will need to review the agreement. Please navigate to INFC and then into one of the systems and review the agreement.)
+  IF agreement_check = "Automated" THEN script_end_procedure("To view INFC data you will need to review the agreement. Please navigate to INFC and then into one of the systems and review the agreement.")
   EMWriteScreen SSN1,  4, 68
   EMWriteScreen SSN2,  4, 71
   EMWriteScreen SSN3,  4, 73
@@ -184,7 +184,7 @@ ElseIf UNEA_radiobutton = 1 then
   call navigate_to_screen("infc", "sves")
   'checking for IRS non-disclosure agreement.
   EMReadScreen agreement_check, 9, 2, 24
-  IF agreement_check = "Automated" THEN script_end_procedure(To view INFC data you will need to review the agreement. Please navigate to INFC and then into one of the systems and review the agreement.)
+  IF agreement_check = "Automated" THEN script_end_procedure("To view INFC data you will need to review the agreement. Please navigate to INFC and then into one of the systems and review the agreement.")
   EMWriteScreen PMI,  5, 68
   EMWriteScreen "qury",  20, 70
   transmit 'Now we will enter the QURY screen to type the claim number.
@@ -237,7 +237,7 @@ ElseIf BNDX_radiobutton = 1 then
   transmit
   'checking for IRS non-disclosure agreement.
   EMReadScreen agreement_check, 9, 2, 24
-  IF agreement_check = "Automated" THEN script_end_procedure(To view INFC data you will need to review the agreement. Please navigate to INFC and then into one of the systems and review the agreement.)
+  IF agreement_check = "Automated" THEN script_end_procedure("To view INFC data you will need to review the agreement. Please navigate to INFC and then into one of the systems and review the agreement.")
   EMWriteScreen "_________", 5, 38
   EMWriteScreen claim_number, 7, 38
   EMWriteScreen "________", 9, 38


### PR DESCRIPTION
Added double-quotes around the SSA agreement script end procedure. The bug is creating a syntax error.