### PR TITLE
Updating PAYSTUBS RECEIVED

### DIFF
--- a/Script Files/ACTIONS/ACTIONS - PAYSTUBS RECEIVED.vbs
+++ b/Script Files/ACTIONS/ACTIONS - PAYSTUBS RECEIVED.vbs
@@ -49,22 +49,17 @@ END IF
 'CUSTOM FUNCTIONS
 
 Function PIC_paystubs_info_adder(pay_date, gross_amt, hours)
-  If isdate(pay_date) = True then
-    If len(datepart("m", pay_date)) = 2 then
-      EMWriteScreen datepart("m", pay_date), PIC_row, 13
-    Else
-      EMWriteScreen "0" & datepart("m", pay_date), PIC_row, 13
-    End if
-    If len(datepart("d", pay_date)) = 2 then
-      EMWriteScreen datepart("d", pay_date), PIC_row, 16
-    Else
-      EMWriteScreen "0" & datepart("d", pay_date), PIC_row, 16
-    End if
-    EMWriteScreen right(datepart("yyyy", pay_date), 2), PIC_row, 19
-    EMWriteScreen gross_amt, PIC_row, 25
-    EMWriteScreen hours, PIC_row, 35
-    PIC_row = PIC_row + 1
-  End If
+	If isdate(pay_date) = True then
+		CALL create_MAXIS_friendly_date(pay_date, 0, PIC_row, 13)
+		EMWriteScreen gross_amt, PIC_row, 25
+		EMWriteScreen hours, PIC_row, 35
+		PIC_row = PIC_row + 1
+		IF PIC_row = 14 THEN
+			PF20
+			PF20
+			PIC_row = 9
+		END IF 
+	End If
 End function
 
 Function prospective_averager(pay_date, gross_amt, hours, paystubs_received, total_prospective_pay, total_prospective_hours) 'Creates variables for total_prospective_pay and total_prospective_hours
@@ -117,40 +112,68 @@ Function retro_paystubs_info_adder(pay_date, gross_amt, hours, retro_hours)
 End function
 
 'DIALOGS----------------------------------------------------------------------------------------------------
-BeginDialog paystubs_received_dialog, 0, 0, 256, 235, "Paystubs Received Dialog"
-  DropListBox 100, 5, 100, 15, "(select one)"+chr(9)+"One Time Per Month"+chr(9)+"Two Times Per Month"+chr(9)+"Every Other Week"+chr(9)+"Every Week", pay_frequency
-  EditBox 15, 45, 65, 15, pay_date_01
-  EditBox 95, 45, 65, 15, gross_amt_01
-  EditBox 175, 45, 65, 15, hours_01
-  EditBox 15, 65, 65, 15, pay_date_02
-  EditBox 95, 65, 65, 15, gross_amt_02
-  EditBox 175, 65, 65, 15, hours_02
-  EditBox 15, 85, 65, 15, pay_date_03
-  EditBox 95, 85, 65, 15, gross_amt_03
-  EditBox 175, 85, 65, 15, hours_03
-  EditBox 15, 105, 65, 15, pay_date_04
-  EditBox 95, 105, 65, 15, gross_amt_04
-  EditBox 175, 105, 65, 15, hours_04
-  EditBox 15, 125, 65, 15, pay_date_05
-  EditBox 95, 125, 65, 15, gross_amt_05
-  EditBox 175, 125, 65, 15, hours_05
-  EditBox 55, 155, 190, 15, explanation_of_income
-  EditBox 95, 175, 80, 15, document_datestamp
-  DropListBox 75, 195, 120, 15, "(select one)"+chr(9)+"1 Pay Stubs/Tip Report"+chr(9)+"2 Empl Statement"+chr(9)+"3 Coltrl Stmt"+chr(9)+"4 Other Document"+chr(9)+"5 Pend Out State Verification"+chr(9)+"N No Ver Prvd", JOBS_verif_code
-  EditBox 75, 215, 115, 15, worker_signature
-  ButtonGroup buttonpressed
-    OkButton 200, 195, 50, 15
-    CancelButton 200, 215, 50, 15
-  Text 40, 10, 55, 10, "Pay frequency:"
-  Text 10, 30, 80, 10, "Pay date (MM/DD/YY):"
-  Text 105, 30, 50, 10, "Gross amount:"
-  Text 195, 30, 30, 10, "Hours:"
-  GroupBox 5, 145, 245, 30, "Explain how income was calculated:"
-  Text 10, 160, 45, 10, "Explanation:"
-  Text 10, 180, 80, 10, "Date paystubs received:"
-  Text 10, 200, 60, 10, "JOBS verif code:"
-  Text 10, 220, 60, 10, "Worker signature:"
+'>>>>> This function creates the dialog that the user inputs all the pay stub information.
+FUNCTION create_paystubs_received_dialog(number_of_paystubs, paystubs_array)
+	'Declaring the multi-dimensional array for handling pay information
+	ReDim paystubs_array(number_of_paystubs - 1, 2)
+
+	BeginDialog paystubs_received_dialog, 0, 0, 256, (160 + (20 * number_of_paystubs - 1)), "Paystubs Received Dialog"
+	  DropListBox 100, 5, 100, 15, "(select one)"+chr(9)+"One Time Per Month"+chr(9)+"Two Times Per Month"+chr(9)+"Every Other Week"+chr(9)+"Every Week", pay_frequency
+	  FOR i = 0 TO (number_of_paystubs - 1)
+		EditBox 15, (45 + (i * 20)), 65, 15, paystubs_array(i, 0)
+		EditBox 95, (45 + (i * 20)), 65, 15, paystubs_array(i, 1)
+		EditBox 175, (45 + (i * 20)), 65, 15, paystubs_array(i, 2)
+	  NEXT
+	  EditBox 55, (80 + (20 * (number_of_paystubs - 1))), 190, 15, explanation_of_income
+	  EditBox 95, (100 + (20 * (number_of_paystubs - 1))), 80, 15, document_datestamp
+	  DropListBox 75, (120 + (20 * (number_of_paystubs - 1))), 120, 15, "(select one)"+chr(9)+"1 Pay Stubs/Tip Report"+chr(9)+"2 Empl Statement"+chr(9)+"3 Coltrl Stmt"+chr(9)+"4 Other Document"+chr(9)+"5 Pend Out State Verification"+chr(9)+"N No Ver Prvd", JOBS_verif_code
+	  EditBox 75, (140 + (20 * (number_of_paystubs - 1))), 115, 15, worker_signature
+	  ButtonGroup buttonpressed
+	  	OkButton 200, (120 + (20 * (number_of_paystubs - 1))), 50, 15
+	  	CancelButton 200, (140 + (20 * (number_of_paystubs - 1))), 50, 15
+	  Text 40, 10, 55, 10, "Pay frequency:"
+	  Text 10, 30, 80, 10, "Pay date (MM/DD/YY):"
+	  Text 105, 30, 50, 10, "Gross amount:"
+	  Text 195, 30, 30, 10, "Hours:"
+	  GroupBox 5, (70 + (20 * (number_of_paystubs - 1))), 245, 30, "Explain how income was calculated:"
+	  Text 10, (85 + (20 * (number_of_paystubs - 1))), 45, 10, "Explanation:"
+	  Text 10, (105 + (20 * (number_of_paystubs - 1))), 80, 10, "Date paystubs received:"
+	  Text 10, (125 + (20 * (number_of_paystubs - 1))), 60, 10, "JOBS verif code:"
+	  Text 10, (145 + (20 * (number_of_paystubs - 1))), 60, 10, "Worker signature:"
+	EndDialog
+	
+	DO	
+		err_msg = ""
+		DIALOG paystubs_received_dialog
+			IF ButtonPressed = 0 THEN stopscript
+			If pay_frequency = "(select one)" then err_msg = err_msg & vbCr & "* You must select a pay frequency."
+			If JOBS_verif_code = "(select one)" then err_msg = err_msg & vbCr & "You must select a JOBS verif code."
+			If explanation_of_income = "" then err_msg = err_msg & vbCr & "* You must explain how you calculated this income (ie: ''all paystubs from last 30 days'')"
+			FOR i = 0 TO (number_of_paystubs - 1)
+				paystubs_array(i, 0) = Trim(paystubs_array(i, 0))
+			NEXT
+			FOR i = 0 TO (number_of_paystubs - 1)
+				If isdate(paystubs_array(i, 0)) = False AND paystubs_array(i, 0) <> "" THEN err_msg = err_msg & vbCr & "* Your pay date must be ''MM/DD/YYYY'' format. Please try again."
+			NEXT
+			FOR i = 0 TO (number_of_paystubs - 1)
+				If isdate(paystubs_array(i, 0)) = True and (Isnumeric(paystubs_array(i, 1)) = False or Isnumeric(paystubs_array(i, 2)) = False) then err_msg = err_msg & vbCr & "* You must include a gross pay amount as well as an hours amount."
+			NEXT
+			FOR i = 0 TO (number_of_paystubs - 1)
+				IF paystubs_array(i, 0) = "" THEN err_msg = err_msg & vbCr & "* You cannot leave pay dates blank."
+				IF paystubs_array(i, 1) = "" OR paystubs_array(i, 2) = "" THEN err_msg = err_msg & vbCr & "* You cannot leave pay information blank."
+			NEXT
+			IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbCr & err_msg & vbCr & vbCr & "Please resolve for the script to continue."
+	LOOP UNTIL err_msg = ""	
+END FUNCTION
+
+BeginDialog number_of_paystubs_dlg, 0, 0, 211, 65, "Number of Pay Dates"
+  EditBox 165, 10, 40, 15, number_of_paystubs
+  ButtonGroup ButtonPressed
+    OkButton 105, 45, 50, 15
+    CancelButton 155, 45, 50, 15
+  Text 10, 15, 145, 10, "Enter the number of pay dates being used..."
 EndDialog
+
 
 BeginDialog paystubs_received_case_number_dialog, 0, 0, 376, 170, "Case number"
   EditBox 100, 5, 60, 15, case_number
@@ -176,8 +199,8 @@ BeginDialog paystubs_received_case_number_dialog, 0, 0, 376, 170, "Case number"
   Text 30, 115, 120, 10, "future months and send through BG."
 EndDialog
 
-
-
+'Declaring arguments that get pulled through the custom function create_paystubs_received_dialog
+DIM worker_signature, explanation_of_income, employer_name, document_datestamp, pay_frequency
 
 'THE SCRIPT----------------------------------------------------------------------------------------------------
 
@@ -202,119 +225,117 @@ End if
 'Default member is member 01
 HH_member = "01"
 
-'Shows the case number dialog
-Dialog paystubs_received_case_number_dialog
-If buttonpressed = 0 then stopscript
+DO
+	'Shows the case number dialog
+	Dialog paystubs_received_case_number_dialog
+		If buttonpressed = 0 then stopscript
+		
+	CALL check_for_MAXIS(False)
+	
+	'Checks to see if it's in STAT, and checks footer month/year. If it isn't in STAT or the right footer month/year, the script will leave the case.
+	EMReadScreen STAT_check, 4, 20, 21
+	EMReadScreen STAT_case_number, 8, 20, 37
+	EMReadScreen STAT_footer_month_check, 2, 20, 55
+	EMReadScreen STAT_footer_year_check, 2, 20, 58
+	If STAT_check <> "STAT" or trim(replace(STAT_case_number, "_", "")) <> case_number or STAT_footer_month_check <> footer_month or STAT_footer_year_check <> footer_year then back_to_SELF
+	
+	call navigate_to_screen("stat", "jobs")
+	
+	'Heads into the case/curr screen, checks to make sure the case number is correct before proceeding. If it can't get beyond the SELF menu the script will stop.
+	EMReadScreen SELF_check, 4, 2, 50
+	If SELF_check = "SELF" then stopscript
+	
+	'Navigates to the JOBS panel for the right person
+	If HH_member <> "01" then 
+	EMWriteScreen HH_member, 20, 76
+	transmit
+	End if
+	
+	'Checks to make sure there are JOBS panels for this member. If none exist the script will close
+	EMReadScreen total_amt_of_panels, 1, 2, 78
+	If total_amt_of_panels = "0" then script_end_procedure("No JOBS panels exist for this client. Please add a JOBS panel and run through background before trying again. The script will now stop.")
+	
+	'If there is more than one panel, this part will grab employer info off of them and present it to the worker to decide which one to use.
+	If total_amt_of_panels <> "1" then
+		Do
+			EMReadScreen current_panel_number, 1, 2, 73
+			EMReadScreen employer_name, 30, 7, 42
+			employer_check = MsgBox("Is this your employer? Employer name: " & trim(replace(employer_name, "_", "")), 3)
+			If employer_check = 2 then stopscript
+			If employer_check = 6 then 
+				employer_found = True
+				exit do
+			END IF
+			If employer_check = 7 and current_panel_number = total_amt_of_panels then 
+				employer_found = False
+				pick_a_different_household_member = MsgBox("You have run through all the possible employers for this person. If you need to select a different household member, press OK. If you need to stop the script to change the case number, create a new job, etc, press CANCEL.", vbOKCancel)
+				IF pick_a_different_household_member = vbCancel THEN stopscript
+				IF pick_a_different_household_member = vkOK THEN EXIT DO
+			End if
+			transmit
+		Loop until current_panel_number = total_amt_of_panels
+	End if
+	
+	'Reads employer name for case note
+	EMReadScreen employer_name, 30, 7, 42			'Read the name
+	employer_name = replace(employer_name, "_", "")		'Clean up the name with replacing underscores 
+	call fix_case(employer_name, 3)				'and using custom fix_case function to set case
+
+LOOP UNTIL employer_found = True
+
+DO
+	DIALOG number_of_paystubs_dlg
+		IF ButtonPressed = 0 THEN stopscript
+		IF IsNumeric(number_of_paystubs) = False THEN MsgBox "Please enter the number of pay dates as a number."
+LOOP UNTIL ButtonPressed = -1 AND number_of_paystubs <> "" AND IsNumeric(number_of_paystubs) = True
 
 'Shows the paystub dialog. Includes logic to prevent paydates from being entered incorrectly.
-Do
-  Do
-    Do
-      Do
-        Do
-          Do
-            Do
-              Do
-                Dialog paystubs_received_dialog
-                If ButtonPressed = 0 then stopscript
-                If pay_frequency = "(select one)" then MsgBox "You must select a pay frequency."
-              Loop until pay_frequency <> "(select one)"
-              If JOBS_verif_code = "(select one)" then MsgBox "You must select a JOBS verif code."
-            Loop until JOBS_verif_code <> "(select one)"
-            If explanation_of_income = "" then MsgBox "You must explain how you calculated this income (ie: ''all paystubs from last 30 days'')"
-          Loop until explanation_of_income <> ""
-          If isdate(pay_date_01) = False then MsgBox "Your pay date must be ''MM/DD/YYYY'' format. Please try again."
-          If isdate(pay_date_01) = True and (Isnumeric(gross_amt_01) = False or Isnumeric(hours_01) = False) then MsgBox "You must include a gross pay amount as well as an hours amount."
-        Loop until (isdate(pay_date_01) = True and (Isnumeric(gross_amt_01) = True and Isnumeric(hours_01) = True))
-        pay_date_02 = trim(pay_date_02)
-        If isdate(pay_date_02) = False and pay_date_02 <> "" then MsgBox "Your pay date must be ''MM/DD/YYYY'' format. Please try again."
-        If isdate(pay_date_02) = True and (Isnumeric(gross_amt_02) = False or Isnumeric(hours_02) = False) then MsgBox "You must include a gross pay amount as well as an hours amount."
-      Loop until (isdate(pay_date_02) = True and (Isnumeric(gross_amt_02) = True and Isnumeric(hours_02) = True)) or pay_date_02 = ""
-      pay_date_03 = trim(pay_date_03)
-      If isdate(pay_date_03) = False and pay_date_03 <> "" then MsgBox "Your pay date must be ''MM/DD/YYYY'' format. Please try again."
-      If isdate(pay_date_03) = True and (Isnumeric(gross_amt_03) = False or Isnumeric(hours_03) = False) then MsgBox "You must include a gross pay amount as well as an hours amount."
-    Loop until (isdate(pay_date_03) = True and (Isnumeric(gross_amt_03) = True and Isnumeric(hours_03) = True)) or pay_date_03 = ""
-    pay_date_04 = trim(pay_date_04)
-    If isdate(pay_date_04) = False and pay_date_04 <> "" then MsgBox "Your pay date must be ''MM/DD/YYYY'' format. Please try again."
-    If isdate(pay_date_04) = True and (Isnumeric(gross_amt_04) = False or Isnumeric(hours_04) = False) then MsgBox "You must include a gross pay amount as well as an hours amount."
-  Loop until (isdate(pay_date_04) = True and (Isnumeric(gross_amt_04) = True and Isnumeric(hours_04) = True)) or pay_date_04 = ""
-  pay_date_05 = trim(pay_date_05)
-  If isdate(pay_date_05) = False and pay_date_05 <> "" then MsgBox "Your pay date must be ''MM/DD/YYYY'' format. Please try again."
-  If isdate(pay_date_05) = True and (Isnumeric(gross_amt_05) = False or Isnumeric(hours_05) = False) then MsgBox "You must include a gross pay amount as well as an hours amount."
-Loop until(isdate(pay_date_05) = True and (Isnumeric(gross_amt_05) = True and Isnumeric(hours_05) = True)) or pay_date_05 = ""
 
-'Checking dates to make sure all are on the same day of the week, in instances of weekly or biweekly income. This avoids a possible issue
-'resulting from a paydate being "moved" due to a holiday, and affecting the rest of the calculation for income. If the dates are not all on the
-'same day, the script will stop.
-If pay_frequency = "Every Other Week" or pay_frequency = "Every Week" then
-	weekday_baseline = weekday(cdate(pay_date_01))
-	If pay_date_02 <> "" then	'Sets these as nested within the If...then, instead of a single line, because of issues trying to run a cdate on a null variable.
-		If weekday(cdate(pay_date_02)) <> weekday_baseline then script_end_procedure(pay_date_02 & " is on a different pay date than the first pay date on the script. This could result in an error when the script calculates prospective pay, so the script will now stop. Please process manually.")
-	End if
-	If pay_date_03 <> "" then
-		If weekday(cdate(pay_date_03)) <> weekday_baseline then script_end_procedure(pay_date_03 & " is on a different pay date than the first pay date on the script. This could result in an error when the script calculates prospective pay, so the script will now stop. Please process manually.")
-	End if
-	If pay_date_04 <> "" then
-		If weekday(cdate(pay_date_04)) <> weekday_baseline then script_end_procedure(pay_date_04 & " is on a different pay date than the first pay date on the script. This could result in an error when the script calculates prospective pay, so the script will now stop. Please process manually.")
-	End if
-	If pay_date_05 <> "" then
-		If weekday(cdate(pay_date_05)) <> weekday_baseline then script_end_procedure(pay_date_05 & " is on a different pay date than the first pay date on the script. This could result in an error when the script calculates prospective pay, so the script will now stop. Please process manually.")
-	End if
-End if
+DO
+	CALL create_paystubs_received_dialog(number_of_paystubs, paystubs_array)
 
-'Sends a transmit to refresh screen, then checks for MAXIS status. Does this on a loop so as not to lose pay information, and includes a cancel button.
-Do
-  transmit
-  EMReadScreen MAXIS_check, 5, 1, 39
-  If MAXIS_check <> "MAXIS" and MAXIS_check <> "AXIS " then
-    MAXIS_check_msgbox = MsgBox("MAXIS not found. You may be passworded out.", 1)
-    If MAXIS_check_msgbox = 2 then stopscript
-  End if
-Loop until MAXIS_check = "MAXIS" or MAXIS_check = "AXIS "
+	err_msg = ""
+	'Checking dates to make sure all are on the same day of the week, in instances of weekly or biweekly income. This avoids a possible issue
+	'resulting from a paydate being "moved" due to a holiday, and affecting the rest of the calculation for income. If the dates are not all on the
+	'same day, the script will stop.
+	If pay_frequency = "Every Other Week" or pay_frequency = "Every Week" then
+		weekday_baseline = weekday(cdate(paystubs_array(0, 0)))
+		list_of_weekdays = "Select one..."
+		list_of_weekdays = list_of_weekdays+chr(9)+WeekDayName(weekday(cdate(paystubs_array(0, 0))))
+		
+		FOR i = 1 TO (number_of_paystubs - 1)
+			IF paystubs_array(i, 0) <> "" THEN 
+				IF WeekDay(CDate(paystubs_array(i, 0))) <> weekday_baseline THEN 
+					err_msg = err_msg & vbCr & (paystubs_array(i, 0) & " is on a different pay date than the first pay date on the script.")
+					IF InStr(list_of_weekdays, WeekDayName(weekday(cdate(paystubs_array(i, 0))))) = 0 THEN list_of_weekdays = list_of_weekdays+chr(9)+WeekDayName(weekday(cdate(paystubs_array(i, 0))))
+				END IF
+			END IF
+		NEXT
+	END IF
+	
+	IF err_msg <> "" THEN 
+		dates_not_aligned = MsgBox("*** NOTICE!!! ***" & vbCr & err_msg & vbCr & vbCr & "The script is going to ask you to pick a specific day of the week to use for prospecting income. Press OK to continue. If you do not want to do this, press CANCEL (the script will end).", vbOKCancel)
+		IF dates_not_aligned = vbCancel THEN script_end_procedure("")
 
-'Checks to see if it's in STAT, and checks footer month/year. If it isn't in STAT or the right footer month/year, the script will leave the case.
-EMReadScreen STAT_check, 4, 20, 21
-EMReadScreen STAT_case_number, 8, 20, 37
-EMReadScreen STAT_footer_month_check, 2, 20, 55
-EMReadScreen STAT_footer_year_check, 2, 20, 58
-If STAT_check <> "STAT" or trim(replace(STAT_case_number, "_", "")) <> case_number or STAT_footer_month_check <> footer_month or STAT_footer_year_check <> footer_year then back_to_SELF
-
-call navigate_to_screen("stat", "jobs")
-
-'Heads into the case/curr screen, checks to make sure the case number is correct before proceeding. If it can't get beyond the SELF menu the script will stop.
-EMReadScreen SELF_check, 4, 2, 50
-If SELF_check = "SELF" then stopscript
-
-'Navigates to the JOBS panel for the right person
-If HH_member <> "01" then 
-  EMWriteScreen HH_member, 20, 76
-  transmit
-End if
-
-'Checks to make sure there are JOBS panels for this member. If none exist the script will close
-EMReadScreen total_amt_of_panels, 1, 2, 78
-If total_amt_of_panels = "0" then script_end_procedure("No JOBS panels exist for this client. Please add a JOBS panel and run through background before trying again. The script will now stop.")
-
-'If there is more than one panel, this part will grab employer info off of them and present it to the worker to decide which one to use.
-If total_amt_of_panels <> "1" then
-  Do
-    EMReadScreen current_panel_number, 1, 2, 73
-    EMReadScreen employer_name, 30, 7, 42
-    employer_check = MsgBox("Is this your employer? Employer name: " & trim(replace(employer_name, "_", "")), 3)
-    If employer_check = 2 then stopscript
-    If employer_check = 6 then exit do
-    If employer_check = 7 and current_panel_number = total_amt_of_panels then 
-      EMWriteScreen "01", 20, 79
-      current_panel_number = "1"
-    End if
-    transmit
-  Loop until current_panel_number = total_amt_of_panels
-End if
-
-'Reads employer name for case note
-EMReadScreen employer_name, 30, 7, 42			'Read the name
-employer_name = replace(employer_name, "_", "")		'Clean up the name with replacing underscores 
-call fix_case(employer_name, 3)				'and using custom fix_case function to set case
+        BeginDialog weekday_dlg, 0, 0, 191, 150, "Pick a Weekday"
+          Text 15, 15, 160, 35, "Pick a specific day of the week for the script to use for prospecting income. The script is using the days of the week from the pay stubs you entered in the previous dialog."
+          Text 15, 70, 40, 10, "Weekday:"
+          DropListBox 65, 70, 70, 15, list_of_weekdays, weekday_to_use
+          ButtonGroup ButtonPressed
+            OkButton 85, 130, 50, 15
+            CancelButton 135, 130, 50, 15
+        EndDialog
+		
+		DO
+			err_msg = ""
+			DIALOG weekday_dlg
+				IF ButtonPressed = 0 THEN stopscript
+				IF weekday_to_use = "Select one..." THEN MsgBox "Select a weekday."
+		LOOP UNTIL weekday_to_use <> "Select one..."
+	ELSE
+		weekday_to_use = WeekDayName(WeekDay(paystubs_array(0, 0)))
+	END IF
+LOOP UNTIL err_msg = ""
 
 'Turns on edit mode
 PF9
@@ -325,12 +346,10 @@ dim total_prospective_pay
 dim total_prospective_hours
 
 'Totals the prospective amounts, inserts "01/01/2000" for dates that were left blank, using function.
+FOR i = 0 TO (number_of_paystubs - 1)
+	Call prospective_averager(paystubs_array(i, 0), paystubs_array(i, 1), paystubs_array(i, 2), paystubs_received, total_prospective_pay, total_prospective_hours)
+NEXT
 
-Call prospective_averager(pay_date_01, gross_amt_01, hours_01, paystubs_received, total_prospective_pay, total_prospective_hours)
-Call prospective_averager(pay_date_02, gross_amt_02, hours_02, paystubs_received, total_prospective_pay, total_prospective_hours)
-Call prospective_averager(pay_date_03, gross_amt_03, hours_03, paystubs_received, total_prospective_pay, total_prospective_hours)
-Call prospective_averager(pay_date_04, gross_amt_04, hours_04, paystubs_received, total_prospective_pay, total_prospective_hours)
-Call prospective_averager(pay_date_05, gross_amt_05, hours_05, paystubs_received, total_prospective_pay, total_prospective_hours)
 
 'Creates averages
 average_pay_per_paystub = formatnumber(total_prospective_pay / paystubs_received, 2, 0, 0, 0)
@@ -338,253 +357,274 @@ average_hours_per_paystub = abs(total_prospective_hours / paystubs_received)
 
 
 Do
-  'If SNAP was active the script must update the PIC.
-  If update_PIC_check = 1 then
-    EMWriteScreen "x", 19, 38
-    transmit
-    'Clears existing info off PIC
-    EMSendKey "<home>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>"
-    'The following will generate a MAXIS formatted date for today. 
-    current_day = DatePart("D", date)
-    If len(current_day) = 1 then current_day = "0" & current_day
-    current_month = DatePart("M", date)
-    If len(current_month) = 1 then current_month = "0" & current_month
-    current_year = right(DatePart("yyyy", date), 2)
-    'Puts current date and pay frequency in PIC.
-    EMWriteScreen current_month, 5, 34
-    EMWriteScreen current_day, 5, 37
-    EMWriteScreen current_year, 5, 40
-    If pay_frequency = "One Time Per Month" then EMWriteScreen "1", 5, 64
-    If pay_frequency = "Two Times Per Month" then EMWriteScreen "2", 5, 64
-    If pay_frequency = "Every Other Week" then EMWriteScreen "3", 5, 64
-    If pay_frequency = "Every Week" then EMWriteScreen "4", 5, 64
-    'Sets PIC row for the next functions
-    PIC_row = 9
-    'Uses function to add each PIC pay date, income, and hours. Doesn't add any if they show "01/01/2000" as those are dummy numbers
-    If pay_date_01 <> "01/01/2000" then call PIC_paystubs_info_adder(pay_date_01, gross_amt_01, hours_01)
-    If pay_date_02 <> "01/01/2000" then call PIC_paystubs_info_adder(pay_date_02, gross_amt_02, hours_02)
-    If pay_date_03 <> "01/01/2000" then call PIC_paystubs_info_adder(pay_date_03, gross_amt_03, hours_03)
-    If pay_date_04 <> "01/01/2000" then call PIC_paystubs_info_adder(pay_date_04, gross_amt_04, hours_04)
-    If pay_date_05 <> "01/01/2000" then call PIC_paystubs_info_adder(pay_date_05, gross_amt_05, hours_05)
-    'Transmits in order to format the PIC
-    transmit
-    transmit  
-    'Reads the contents of the PIC for case noting.
-    EMReadScreen PIC_line_01, 26, 5, 49
-    EMReadScreen PIC_line_02, 28, 8, 13
-    EMReadScreen PIC_line_03, 28, 9, 13
-    EMReadScreen PIC_line_04, 28, 10, 13
-    EMReadScreen PIC_line_05, 28, 11, 13
-    EMReadScreen PIC_line_06, 28, 12, 13
-    EMReadScreen PIC_line_07, 28, 13, 13
-    EMReadScreen PIC_line_08, 28, 14, 13
-    EMReadScreen PIC_line_09, 50, 16, 22
-    EMReadScreen PIC_line_10, 50, 17, 22
-    EMReadScreen PIC_line_11, 50, 18, 22
-    transmit
+	'If SNAP was active the script must update the PIC.
+	If update_PIC_check = 1 then
+		IF number_of_paystubs > 10 THEN 
+			MsgBox "You indicated you are using more than 10 pay dates. The PIC cannot handle more than 10 pay dates. The script will not be able to update the PIC. You will need to process the PIC manually."
+		ELSE
+			EMWriteScreen "x", 19, 38
+			transmit
+		
+		'Determining if there is a page 2 on the PIC
+		PF20
+		EMReadScreen complete_the_page, 17, 20, 6
+		IF complete_the_page <> "COMPLETE THE PAGE" THEN 
+			FOR a = 9 to 13
+				EMSetCursor a, 13
+				EMSendKey "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>"
+			NEXT
+			PF19
+			PF19
+		END IF
+		'Clears existing info off PIC
+		EMSendKey "<home>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>" + "<tab>" + "<eraseeof>"
+
+		'The following will generate a MAXIS formatted date for today. 
+		current_day = DatePart("D", date)
+		If len(current_day) = 1 then current_day = "0" & current_day
+		current_month = DatePart("M", date)
+		If len(current_month) = 1 then current_month = "0" & current_month
+		current_year = right(DatePart("yyyy", date), 2)
+		'Puts current date and pay frequency in PIC.
+		CALL create_MAXIS_friendly_date(date, 0, 5, 34)
+		If pay_frequency = "One Time Per Month" then EMWriteScreen "1", 5, 64
+		If pay_frequency = "Two Times Per Month" then EMWriteScreen "2", 5, 64
+		If pay_frequency = "Every Other Week" then EMWriteScreen "3", 5, 64
+		If pay_frequency = "Every Week" then EMWriteScreen "4", 5, 64
+		'Sets PIC row for the next functions
+		DIM PIC_row
+		PIC_row = 9
+		'Uses function to add each PIC pay date, income, and hours. Doesn't add any if they show "01/01/2000" as those are dummy numbers
+		FOR i = 0 to (number_of_paystubs - 1)
+			IF paystubs_array(i, 0) <> "01/01/2000" THEN CALL PIC_paystubs_info_adder(paystubs_array(i, 0), paystubs_array(i, 1), paystubs_array(i, 2))
+		NEXT
+		
+		'Transmits in order to format the PIC
+		transmit
+		transmit  
+		'Reads the contents of the PIC for case noting.
+		EMReadScreen PIC_line_01, 26, 5, 49
+		EMReadScreen PIC_line_02, 28, 8, 13
+		EMReadScreen PIC_line_03, 28, 9, 13
+		EMReadScreen PIC_line_04, 28, 10, 13
+		EMReadScreen PIC_line_05, 28, 11, 13
+		EMReadScreen PIC_line_06, 28, 12, 13
+		EMReadScreen PIC_line_07, 28, 13, 13
+		EMReadScreen PIC_line_08, 28, 14, 13
+		EMReadScreen PIC_line_09, 50, 16, 22
+		EMReadScreen PIC_line_10, 50, 17, 22
+		EMReadScreen PIC_line_11, 50, 18, 22
+		transmit
+	END IF
   End if
   
   
-  'Clears JOBS data before updating the JOBS panel
-  EMSetCursor 12, 25
-  EMSendKey "___________________________________________________________________________________________________________________________________________________"
+	'Clears JOBS data before updating the JOBS panel
+	EMSetCursor 12, 25
+	EMSendKey "___________________________________________________________________________________________________________________________________________________"
   
-  'Updates for retrospective income by checking each pay date's month against the footer month using a function. If the footer month is two months ahead of the pay month it will add to JOBS and keep a tally of hours.
-  MAXIS_row = 12 'Needs this for the following functions
-  Dim retro_hours
-  call retro_paystubs_info_adder(pay_date_01, gross_amt_01, hours_01, retro_hours)
-  call retro_paystubs_info_adder(pay_date_02, gross_amt_02, hours_02, retro_hours)
-  call retro_paystubs_info_adder(pay_date_03, gross_amt_03, hours_03, retro_hours)
-  call retro_paystubs_info_adder(pay_date_04, gross_amt_04, hours_04, retro_hours)
-  call retro_paystubs_info_adder(pay_date_05, gross_amt_05, hours_05, retro_hours)
+	'Updates for retrospective income by checking each pay date's month against the footer month using a function. If the footer month is two months ahead of the pay month it will add to JOBS and keep a tally of hours.
+	MAXIS_row = 12 'Needs this for the following functions
+	Dim retro_hours
+	FOR i = 0 TO (number_of_paystubs - 1)
+		CALL retro_paystubs_info_adder(paystubs_array(i, 0), paystubs_array(i, 1), paystubs_array(i, 2), retro_hours)
+	NEXT
   
-  'Must convert retro hours into an integer for MAXIS
-  retro_hours = retro_hours + .00000000000001 'This will force rounding to go half-up, as the CINT function rounds half down, which goes against procedure.
-  retro_hours = cint(retro_hours)
+	'Must convert retro hours into an integer for MAXIS
+	retro_hours = retro_hours + .00000000000001 'This will force rounding to go half-up, as the CINT function rounds half down, which goes against procedure.
+	retro_hours = cint(retro_hours)
   
-  'Puts hours worked in the retro months in. This was determined using the previous functions.
-  If retro_hours > 999 then retro_hours = 999 'In case there are over 999 hours, this is the procedure
-  If retro_hours <> "" and retro_hours <> 0 then EMWriteScreen retro_hours, 18, 43
-  retro_hours = 0 'Clears variable so it can be used in multiple months if needed
+	'Puts hours worked in the retro months in. This was determined using the previous functions.
+	If retro_hours > 999 then retro_hours = 999 'In case there are over 999 hours, this is the procedure
+	If retro_hours <> "" and retro_hours <> 0 then EMWriteScreen retro_hours, 18, 43
+	retro_hours = 0 'Clears variable so it can be used in multiple months if needed
   
-  'Determines the paydate to put in the prospective side. It moves forward for instances where the footer month is ahead of the first paydate, otherwise it moves backward until it lands on the right date.
-  first_prospective_pay_date = pay_date_01
-  If datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) > 0 then 'For instances where the footer month is ahead of the first paydate.
-    Do
-      If datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) = 0 then exit do
-      If pay_frequency = "One Time Per Month" then first_prospective_pay_date = dateadd("m", 1, first_prospective_pay_date)
-      If pay_frequency = "Two Times Per Month" then first_prospective_pay_date = dateadd("m", 1, first_prospective_pay_date)
-      If pay_frequency = "Every Other Week" then first_prospective_pay_date = dateadd("d", 14, first_prospective_pay_date)
-      If pay_frequency = "Every Week" then first_prospective_pay_date = dateadd("d", 7, first_prospective_pay_date)
-    Loop until datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) = 0
-  Elseif datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) < 0 then 'For instances where the footer month is behind the first paydate (ex: paydate is 06/26/2013 but footer month is 05/13).
-    Do
-      If datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) = 0 then exit do
-      If pay_frequency = "One Time Per Month" then first_prospective_pay_date = dateadd("m", -1, first_prospective_pay_date)
-      If pay_frequency = "Two Times Per Month" then first_prospective_pay_date = dateadd("m", -1, first_prospective_pay_date)
-      If pay_frequency = "Every Other Week" then first_prospective_pay_date = dateadd("d", -14, first_prospective_pay_date)
-      If pay_frequency = "Every Week" then first_prospective_pay_date = dateadd("d", -7, first_prospective_pay_date)
-    Loop until datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) = 0
-  End if
+	'Determines the paydate to put in the prospective side. It moves forward for instances where the footer month is ahead of the first paydate, otherwise it moves backward until it lands on the right date.
+	first_prospective_pay_date = ""
+	FOR i = 0 TO (number_of_paystubs - 1)
+		IF WeekDayName(WeekDay(paystubs_array(i, 0))) = weekday_to_use THEN 
+			IF first_prospective_pay_date = "" THEN 
+				first_prospective_pay_date = paystubs_array(i, 0)
+			ELSE
+				'If the paystubs_array(i, 0) is earlier than the existing first_prospective_pay_date THEN the script resets first_prospective_pay_date with the value of paystubs_array(i, 0)
+				IF DateDiff("D", first_prospective_pay_date, paystubs_array(i, 0)) < 0 THEN first_prospective_pay_date = paystubs_array(i, 0)
+			END IF
+		END IF
+	NEXT
   
-  'This checks to make sure the earliest possible paydate is selected in each prospective month.
-  If pay_frequency = "Two Times Per Month" or pay_frequency = "Every Other Week" or pay_frequency = "Every Week" then 
-    Do
-      If pay_frequency = "Two Times Per Month" and datepart("d", first_prospective_pay_date) > 15 then first_prospective_pay_date = dateadd("d", -15, first_prospective_pay_date)
-      If pay_frequency = "Every Other Week" and datepart("d", first_prospective_pay_date) > 14 then first_prospective_pay_date = dateadd("d", -14, first_prospective_pay_date)
-      If pay_frequency = "Every Week" and datepart("d", first_prospective_pay_date) > 7 then first_prospective_pay_date = dateadd("d", -7, first_prospective_pay_date)
-    Loop until (pay_frequency = "Two Times Per Month" and datepart("d", first_prospective_pay_date) <= 15) or (pay_frequency = "Every Other Week" and datepart("d", first_prospective_pay_date) <= 14) or (pay_frequency = "Every Week" and datepart("d", first_prospective_pay_date) <= 7)
-  End if
+	If datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) > 0 then 'For instances where the footer month is ahead of the first paydate.
+		Do
+			If datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) = 0 then exit do
+			If pay_frequency = "One Time Per Month" then first_prospective_pay_date = dateadd("m", 1, first_prospective_pay_date)
+			If pay_frequency = "Two Times Per Month" then first_prospective_pay_date = dateadd("m", 1, first_prospective_pay_date)
+			If pay_frequency = "Every Other Week" then first_prospective_pay_date = dateadd("d", 14, first_prospective_pay_date)
+			If pay_frequency = "Every Week" then first_prospective_pay_date = dateadd("d", 7, first_prospective_pay_date)
+		Loop until datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) = 0
+	Elseif datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) < 0 then 'For instances where the footer month is behind the first paydate (ex: paydate is 06/26/2013 but footer month is 05/13).
+		Do
+			If datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) = 0 then exit do
+			If pay_frequency = "One Time Per Month" then first_prospective_pay_date = dateadd("m", -1, first_prospective_pay_date)
+			If pay_frequency = "Two Times Per Month" then first_prospective_pay_date = dateadd("m", -1, first_prospective_pay_date)
+			If pay_frequency = "Every Other Week" then first_prospective_pay_date = dateadd("d", -14, first_prospective_pay_date)
+			If pay_frequency = "Every Week" then first_prospective_pay_date = dateadd("d", -7, first_prospective_pay_date)
+		Loop until datediff("m", first_prospective_pay_date, footer_month & "/01/" & footer_year) = 0
+	End if
+  
+	'This checks to make sure the earliest possible paydate is selected in each prospective month.
+	If pay_frequency = "Two Times Per Month" or pay_frequency = "Every Other Week" or pay_frequency = "Every Week" then 
+		Do
+			If pay_frequency = "Two Times Per Month" and datepart("d", first_prospective_pay_date) > 15 then first_prospective_pay_date = dateadd("d", -15, first_prospective_pay_date)
+			If pay_frequency = "Every Other Week" and datepart("d", first_prospective_pay_date) > 14 then first_prospective_pay_date = dateadd("d", -14, first_prospective_pay_date)
+			If pay_frequency = "Every Week" and datepart("d", first_prospective_pay_date) > 7 then first_prospective_pay_date = dateadd("d", -7, first_prospective_pay_date)
+		Loop until (pay_frequency = "Two Times Per Month" and datepart("d", first_prospective_pay_date) <= 15) or (pay_frequency = "Every Other Week" and datepart("d", first_prospective_pay_date) <= 14) or (pay_frequency = "Every Week" and datepart("d", first_prospective_pay_date) <= 7)
+	End if
 
 
-  'Analyzes the paystubs received using a function, puts any actual paystubs received in the footer month into the JOBS panel on the prospective side.
-  MAXIS_row = 12 'This variable is needed for the script to know which line to put the prospective info on
-  call prospective_pay_analyzer(pay_date_01, gross_amt_01)
-  call prospective_pay_analyzer(pay_date_02, gross_amt_02)
-  call prospective_pay_analyzer(pay_date_03, gross_amt_03)
-  call prospective_pay_analyzer(pay_date_04, gross_amt_04)
-  call prospective_pay_analyzer(pay_date_05, gross_amt_05)
-  total_prospective_dates = MAXIS_row - 12
+	'Analyzes the paystubs received using a function, puts any actual paystubs received in the footer month into the JOBS panel on the prospective side.
+	MAXIS_row = 12 'This variable is needed for the script to know which line to put the prospective info on
+	FOR i = 0 TO (number_of_paystubs - 1)
+		CALL prospective_pay_analyzer(paystubs_array(i, 0), paystubs_array(i, 1))
+	NEXT
+	total_prospective_dates = MAXIS_row - 12
 
-  'Adds the remaining weeks in using a do...loop to determine all of the anticipated pay dates for the client.
-  If pay_frequency = "One Time Per Month" then pay_multiplier = 31
-  If pay_frequency = "Two Times Per Month" then pay_multiplier = 15
-  If pay_frequency = "Every Other Week" then pay_multiplier = 14
-  If pay_frequency = "Every Week" then pay_multiplier = 7
-  Do
-    If pay_frequency = "One Time Per Month" and total_prospective_dates >= 1 then exit do 'Shouldn't be more than one entry if pay is once per month.
-    If pay_frequency = "Two Times Per Month" and total_prospective_dates >= 2 then exit do 'Shouldn't be more than two entries if pay is twice per month.
-    prospective_pay_date = dateadd("d", total_prospective_dates * pay_multiplier, first_prospective_pay_date)
-    If datediff("m", prospective_pay_date, footer_month & "/01/" & footer_year) = 0 then
-      If len(datepart("m", prospective_pay_date)) = 2 then
-        EMWriteScreen datepart("m", prospective_pay_date), MAXIS_row, 54
-      Else
-        EMWriteScreen "0" & datepart("m", prospective_pay_date), MAXIS_row, 54
-      End if
-      If len(datepart("d", prospective_pay_date)) = 2 then
-        EMWriteScreen datepart("d", prospective_pay_date), MAXIS_row, 57
-      Else
-        EMWriteScreen "0" & datepart("d", prospective_pay_date), MAXIS_row, 57
-      End if
-      EMWriteScreen right(datepart("yyyy", prospective_pay_date), 2), MAXIS_row, 60
-      EMWriteScreen average_pay_per_paystub, MAXIS_row, 67
-      MAXIS_row = MAXIS_row + 1
-      total_prospective_dates = total_prospective_dates + 1
-    End if
-  Loop until datediff("m", prospective_pay_date, footer_month & "/01/" & footer_year) <> 0
+	'Adds the remaining weeks in using a do...loop to determine all of the anticipated pay dates for the client.
+	If pay_frequency = "One Time Per Month" then pay_multiplier = 31
+	If pay_frequency = "Two Times Per Month" then pay_multiplier = 15
+	If pay_frequency = "Every Other Week" then pay_multiplier = 14
+	If pay_frequency = "Every Week" then pay_multiplier = 7
   
-  'Updates pay frequency
-  If pay_frequency = "One Time Per Month" then EMWriteScreen "1", 18, 35
-  If pay_frequency = "Two Times Per Month" then EMWriteScreen "2", 18, 35
-  If pay_frequency = "Every Other Week" then EMWriteScreen "3", 18, 35
-  If pay_frequency = "Every Week" then EMWriteScreen "4", 18, 35
-  
-  'Puts average hours in. Added a small imperfection ".0000000000001" so that if any hourly amounts land on exactly ".5", they will round half-up instead of half down.
-  If pay_frequency = "One Time Per Month" then EMWriteScreen cint(average_hours_per_paystub + .0000000000001), 18, 72
-  If pay_frequency = "Two Times Per Month" then EMWriteScreen cint((average_hours_per_paystub + .0000000000001) * total_prospective_dates), 18, 72
-  If pay_frequency = "Every Other Week" then EMWriteScreen cint((average_hours_per_paystub + .0000000000001) * total_prospective_dates), 18, 72
-  If pay_frequency = "Every Week" then EMWriteScreen cint((average_hours_per_paystub + .0000000000001) * total_prospective_dates), 18, 72
-  
-  'Puts pay verification type in
-  EMWriteScreen left(JOBS_verif_code, 1), 6, 38
-  
-  'If the footer month is the current month + 1, the script needs to update the HC popup for HC cases.
-  If update_HC_popup_check = 1 and datediff("m", date, footer_month & "/01/" & footer_year) = 1 then 
-    EMWriteScreen "x", 19, 54
-    transmit
-    EMWriteScreen "________", 11, 63
-    EMWriteScreen average_pay_per_paystub, 11, 63
-    Do 'Doing this as a pop-up since there are times when a warning message changes the amount of times this plays.
-      transmit
-      EMReadScreen HC_popup_check, 18, 9, 43
-      If HC_popup_check <> "HC Income Estimate" then updated_HC_popup = True
-    Loop until HC_popup_check <> "HC Income Estimate"
-  End if
-  
-  'Transmits after ending the JOBS panel updating
-  Do
-    transmit
-    EMReadScreen display_mode_check, 1, 20, 8
-  Loop until display_mode_check = "D"
-  
-  If datediff("m", date, footer_month & "/01/" & footer_year) = 1 then in_future_month = True
-  
-  'If just on SNAP, the case does not have to update future months, so the script can now case note.
-  If future_months_check = 0 or in_future_month = True then exit do
-  
-  'Navigates to the current month + 1 footer month, then back into the JOBS panel
-  EMWriteScreen "bgtx", 20, 71
-  transmit
-  EMWriteScreen "y", 16, 54
-  transmit
-  EMReadScreen footer_month, 2, 20, 55
-  EMReadScreen footer_year, 2, 20, 58
-  EMWriteScreen "jobs", 20, 71
-  EMWriteScreen HH_member, 20, 76
-  If len(current_panel_number) = 1 then current_panel_number = "0" & current_panel_number
-  EMWriteScreen current_panel_number, 20, 79
-  transmit
-  PF9
+	Do
+		If pay_frequency = "One Time Per Month" and total_prospective_dates >= 1 then exit do 'Shouldn't be more than one entry if pay is once per month.
+		If pay_frequency = "Two Times Per Month" and total_prospective_dates >= 2 then exit do 'Shouldn't be more than two entries if pay is twice per month.
+		prospective_pay_date = dateadd("d", total_prospective_dates * pay_multiplier, first_prospective_pay_date)
+		If datediff("m", prospective_pay_date, footer_month & "/01/" & footer_year) = 0 then
+			If len(datepart("m", prospective_pay_date)) = 2 then
+				EMWriteScreen datepart("m", prospective_pay_date), MAXIS_row, 54
+			Else
+				EMWriteScreen "0" & datepart("m", prospective_pay_date), MAXIS_row, 54
+			End if
+			If len(datepart("d", prospective_pay_date)) = 2 then
+				EMWriteScreen datepart("d", prospective_pay_date), MAXIS_row, 57
+			Else
+				EMWriteScreen "0" & datepart("d", prospective_pay_date), MAXIS_row, 57
+			End if
+			EMWriteScreen right(datepart("yyyy", prospective_pay_date), 2), MAXIS_row, 60
+			EMWriteScreen average_pay_per_paystub, MAXIS_row, 67
+			MAXIS_row = MAXIS_row + 1
+			total_prospective_dates = total_prospective_dates + 1
+		End if
+	Loop until datediff("m", prospective_pay_date, footer_month & "/01/" & footer_year) <> 0
 
+	'Updates pay frequency
+	If pay_frequency = "One Time Per Month" then EMWriteScreen "1", 18, 35
+	If pay_frequency = "Two Times Per Month" then EMWriteScreen "2", 18, 35
+	If pay_frequency = "Every Other Week" then EMWriteScreen "3", 18, 35
+	If pay_frequency = "Every Week" then EMWriteScreen "4", 18, 35
+  
+	'Puts average hours in. Added a small imperfection ".0000000000001" so that if any hourly amounts land on exactly ".5", they will round half-up instead of half down.
+	If pay_frequency = "One Time Per Month" then EMWriteScreen cint(average_hours_per_paystub + .0000000000001), 18, 72
+	If pay_frequency = "Two Times Per Month" then EMWriteScreen cint((average_hours_per_paystub + .0000000000001) * total_prospective_dates), 18, 72
+	If pay_frequency = "Every Other Week" then EMWriteScreen cint((average_hours_per_paystub + .0000000000001) * total_prospective_dates), 18, 72
+	If pay_frequency = "Every Week" then EMWriteScreen cint((average_hours_per_paystub + .0000000000001) * total_prospective_dates), 18, 72
+  
+	'Puts pay verification type in
+	EMWriteScreen left(JOBS_verif_code, 1), 6, 38
+  
+	'If the footer month is the current month + 1, the script needs to update the HC popup for HC cases.
+	If update_HC_popup_check = 1 and datediff("m", date, footer_month & "/01/" & footer_year) = 1 then 
+		EMWriteScreen "x", 19, 54
+		transmit
+		EMWriteScreen "________", 11, 63
+		EMWriteScreen average_pay_per_paystub, 11, 63
+		Do 'Doing this as a pop-up since there are times when a warning message changes the amount of times this plays.
+			transmit
+			EMReadScreen HC_popup_check, 18, 9, 43
+			If HC_popup_check <> "HC Income Estimate" then updated_HC_popup = True
+		Loop until HC_popup_check <> "HC Income Estimate"
+	End if
+  
+	'Transmits after ending the JOBS panel updating
+	Do
+		transmit
+		EMReadScreen display_mode_check, 1, 20, 8
+	Loop until display_mode_check = "D"
+  
+	If datediff("m", date, footer_month & "/01/" & footer_year) = 1 then in_future_month = True
+  
+	'If just on SNAP, the case does not have to update future months, so the script can now case note.
+	If future_months_check = 0 or in_future_month = True then exit do
+  
+	'Navigates to the current month + 1 footer month, then back into the JOBS panel
+	CALL write_value_and_transmit("BGTX", 20, 71)
+	CALL write_value_and_transmit("y", 16, 54)
+	EMReadScreen footer_month, 2, 20, 55
+	EMReadScreen footer_year, 2, 20, 58
+	EMWriteScreen "jobs", 20, 71
+	EMWriteScreen HH_member, 20, 76
+	If len(current_panel_number) = 1 then current_panel_number = "0" & current_panel_number
+	EMWriteScreen current_panel_number, 20, 79
+	transmit
+	PF9
 Loop until in_future_month = True
 
 'Determines if the case note should add additional info about which HH member had the paystubs
 If HH_member <> "01" then
-  HH_memb_for_case_note = " for memb " & HH_member 
+	HH_memb_for_case_note = " for memb " & HH_member 
 Else
-  HH_memb_for_case_note = ""
+	HH_memb_for_case_note = ""
 End if
 
 'Case noting section
 If update_PIC_check = 1 then
-  PF4
-  PF9
-  EMSendKey "~~~SNAP PIC" & HH_memb_for_case_note & ": " & date & "~~~" & "<newline>"
-  EMSendKey PIC_line_02 & "<newline>"
-  EMSendKey PIC_line_03 & "                 " & "<newline>"
-  EMSendKey PIC_line_04 & "                 " & "<newline>"
-  EMSendKey PIC_line_05 & "                 " & "<newline>"
-  EMSendKey PIC_line_06 & "                 " & "<newline>"
-  EMSendKey PIC_line_07 & "<newline>"
-  EMSendKey PIC_line_08 & "<newline>"
-  EMWriteScreen PIC_line_01, 6, 48
-  EMWriteScreen PIC_line_09, 7, 35
-  EMWriteScreen PIC_line_10, 8, 35
-  EMWriteScreen PIC_line_11, 9, 35
-  If explanation_of_income <> "" then 
-    EMSendKey "---" & "<newline>"
-    call write_editbox_in_case_note("How income was calculated", explanation_of_income, 6)
-  End if
-  call write_editbox_in_case_note("Employer name", employer_name, 6)
-  If document_datestamp <> "" then call write_editbox_in_case_note("Paystubs received date", document_datestamp, 6)
-  call write_new_line_in_case_note("---")
-  call write_new_line_in_case_note(worker_signature)
-  PF3
-  PF3
+	PF4
+	PF9
+	EMSendKey "~~~SNAP PIC" & HH_memb_for_case_note & ": " & date & "~~~" & "<newline>"
+	EMSendKey PIC_line_02 & "<newline>"
+	EMSendKey PIC_line_03 & "                 " & "<newline>"
+	EMSendKey PIC_line_04 & "                 " & "<newline>"
+	EMSendKey PIC_line_05 & "                 " & "<newline>"
+	EMSendKey PIC_line_06 & "                 " & "<newline>"
+	EMSendKey PIC_line_07 & "<newline>"
+	EMSendKey PIC_line_08 & "<newline>"
+	EMWriteScreen PIC_line_01, 6, 48
+	EMWriteScreen PIC_line_09, 7, 35
+	EMWriteScreen PIC_line_10, 8, 35
+	EMWriteScreen PIC_line_11, 9, 35
+	If explanation_of_income <> "" then 
+		EMSendKey "---" & "<newline>"
+		call write_bullet_and_variable_in_CASE_NOTE("How income was calculated", explanation_of_income)
+	End if
+	call write_bullet_and_variable_in_CASE_NOTE("Employer name", employer_name)
+	If document_datestamp <> "" then call write_bullet_and_variable_in_CASE_NOTE("Paystubs received date", document_datestamp)
+	call write_variable_in_CASE_NOTE("---")
+	call write_variable_in_CASE_NOTE(worker_signature)
+	PF3
+	PF3
 End if
 
 If case_note_check = 1 then
-  PF4
-  PF9
-  EMSendKey "Paystubs Received" & HH_memb_for_case_note & ": updated JOBS w/script" & "<newline>"
-  call write_three_columns_in_case_note(14, "DATE", 29, "AMT", 39, "HOURS")
-  If pay_date_01 <> "01/01/2000" then call write_three_columns_in_case_note(12, pay_date_01, 27, "$" & gross_amt_01, 39, hours_01)
-  If pay_date_02 <> "01/01/2000" then call write_three_columns_in_case_note(12, pay_date_02, 27, "$" & gross_amt_02, 39, hours_02)
-  If pay_date_03 <> "01/01/2000" then call write_three_columns_in_case_note(12, pay_date_03, 27, "$" & gross_amt_03, 39, hours_03)
-  If pay_date_04 <> "01/01/2000" then call write_three_columns_in_case_note(12, pay_date_04, 27, "$" & gross_amt_04, 39, hours_04)
-  If pay_date_05 <> "01/01/2000" then call write_three_columns_in_case_note(12, pay_date_05, 27, "$" & gross_amt_05, 39, hours_05)
-  If explanation_of_income <> "" then 
-    EMSendKey "---" & "<newline>"
-    call write_editbox_in_case_note("How income was calculated", explanation_of_income, 6)
-  End if
-  call write_editbox_in_case_note("Employer name", employer_name, 6)
-  If document_datestamp <> "" then call write_editbox_in_case_note("Paystubs received date", document_datestamp, 6)
-  call write_new_line_in_case_note("---")
-  call write_new_line_in_case_note(worker_signature)
-  PF3
-  PF3
+	PF4
+	PF9
+	EMSendKey "Paystubs Received" & HH_memb_for_case_note & ": updated JOBS w/script" & "<newline>"
+	call write_three_columns_in_case_note(14, "DATE", 29, "AMT", 39, "HOURS")
+	FOR i = 0 TO (number_of_paystubs - 1)
+		IF paystubs_array(i, 0) <> "01/01/2000" THEN CALL write_three_columns_in_case_note(12, paystubs_array(i, 0), 27, "$" & paystubs_array(i, 1), 39, paystubs_array(i, 2))
+	NEXT
+	If explanation_of_income <> "" then 
+		EMSendKey "---" & "<newline>"
+		call write_bullet_and_variable_in_CASE_NOTE("How income was calculated", explanation_of_income)
+	End if
+	call write_bullet_and_variable_in_CASE_NOTE("Employer name", employer_name)
+	If document_datestamp <> "" then call write_bullet_and_variable_in_CASE_NOTE("Paystubs received date", document_datestamp)
+	call write_variable_in_CASE_NOTE("---")
+	call write_variable_in_CASE_NOTE(worker_signature)
+	PF3
+	PF3
 End if
 
-MsgBox "Success! Your JOBS panel has been updated with the paystubs you've entered in. Send your case through background, review the results, and take action as appropriate. Don't forget to case note!" 
+IF number_of_paystubs > 5 THEN 
+	MsgBox "Success!! Your JOBS panel has been updated. However, because you have used more than 5 pay dates, the script may not have updated the retro side appropriately, please double check the retro side of your JOBS panel. You may need to manually update it to get the pay information updated correctly."
+ELSE
+	MsgBox "Success!! Your JOBS panel has been updated with the paystubs you've entered in. Send your case through background, review the results, and take action as appropriate. Don't forget to case note!" 
+END IF
 script_end_procedure("")
-


### PR DESCRIPTION
Things that are updated...
- PIC_paystubs_info_adder function
---> Modified PIC handling to allow for second page
- Created create_paystubs_received_dialog function
---> Allows the script to handle as many pay dates as the user needs 
---> Resolves #91 
- Modified order of dialogs
---> User selects the household member and the job BEFORE entering pay information
---> User has the option of changing the household member during the script if all jobs for the current household member are rejected
- Created dialog and modified DO/LOOP to have script figure out which day of week to use for prospecting income
- Added MsgBoxes to warn users of problematic scenarios
---> Does not allow the user to enter future pay dates (resolves #572 )
---> If the user is trying to enter more than 10 pay dates, the script will not update the PIC
---> If the user is trying to use more than 5 pay dates, the user is reminded to double check the RETRO side of JOBS
- Updated custom functions for case noting
---> replaced "write_editbox_in_case_note" with "write_bullet_and_variable_in_case_note"
---> replaced "write_new_line_in_case_note" with "write_variable_in_case_note"