### PR TITLE
Exp snap ebt info enchancement

### DIFF
--- a/Script Files/NOTES/NOTES - EXPEDITED SCREENING.vbs
+++ b/Script Files/NOTES/NOTES - EXPEDITED SCREENING.vbs
@@ -142,6 +142,12 @@ Else
 	has_DISQ = True
 End if
 
+'Reads MONY/DISB to see if EBT account is open 
+IF expedited_status = "client appears expedited" THEN 
+	Call navigate_to_MAXIS_screen("MONY", "DISB")
+	EMReadScreen EBT_account_status, 1, 14, 27
+END IF 
+
 'THE CASE NOTE----------------------------------------------------------------------------------------------------
 Call start_a_blank_CASE_NOTE
 Call write_variable_in_CASE_NOTE("Received " & application_type & ", " & expedited_status)
@@ -153,6 +159,8 @@ call write_variable_in_CASE_NOTE("        Utilities (amt/HEST claimed): $" & uti
 call write_variable_in_CASE_NOTE("---")
 If has_DISQ = True then call write_variable_in_CASE_NOTE("A DISQ panel exists for someone on this case.")
 If has_DISQ = False then call write_variable_in_CASE_NOTE("No DISQ panels were found for this case.")
+If expedited_status = "client appears expedited" AND EBT_account_status = "Y" then call write_variable_in_CASE_NOTE("* EBT Account IS open.  Recipient will be able to get a replacement card in the agency.  Rapid Electronic Issuance (REI) with caution.")
+If expedited_status = "client appears expedited" AND EBT_account_status = "N" then call write_variable_in_CASE_NOTE("* EBT Account is NOT open.  Recipient is able to get initial card in the agency.  Rapid Electronic Issuance (REI) can be used, but only to avoid an emergency issuance or to meet EXP criteria.")
 call write_variable_in_CASE_NOTE("---")
 call write_variable_in_CASE_NOTE(worker_signature)
 If expedited_status = "client appears expedited" then

--- a/Script Files/NOTES/NOTES - EXPEDITED SCREENING.vbs
+++ b/Script Files/NOTES/NOTES - EXPEDITED SCREENING.vbs
@@ -142,12 +142,6 @@ Else
 	has_DISQ = True
 End if
 
-'Reads MONY/DISB to see if EBT account is open 
-IF expedited_status = "client appears expedited" THEN 
-	Call navigate_to_MAXIS_screen("MONY", "DISB")
-	EMReadScreen EBT_account_status, 1, 14, 27
-END IF 
-
 'THE CASE NOTE----------------------------------------------------------------------------------------------------
 Call start_a_blank_CASE_NOTE
 Call write_variable_in_CASE_NOTE("Received " & application_type & ", " & expedited_status)
@@ -159,8 +153,6 @@ call write_variable_in_CASE_NOTE("        Utilities (amt/HEST claimed): $" & uti
 call write_variable_in_CASE_NOTE("---")
 If has_DISQ = True then call write_variable_in_CASE_NOTE("A DISQ panel exists for someone on this case.")
 If has_DISQ = False then call write_variable_in_CASE_NOTE("No DISQ panels were found for this case.")
-If expedited_status = "client appears expedited" AND EBT_account_status = "Y" then call write_variable_in_CASE_NOTE("* EBT Account IS open.  Recipient will be able to get a replacement card in the agency.  Rapid Electronic Issuance (REI) with caution.")
-If expedited_status = "client appears expedited" AND EBT_account_status = "N" then call write_variable_in_CASE_NOTE("* EBT Account is NOT open.  Recipient is able to get initial card in the agency.  Rapid Electronic Issuance (REI) can be used, but only to avoid an emergency issuance or to meet EXP criteria.")
 call write_variable_in_CASE_NOTE("---")
 call write_variable_in_CASE_NOTE(worker_signature)
 If expedited_status = "client appears expedited" then


### PR DESCRIPTION
Resolves issue #1040 
 Here’s how the script differs from the original:
If the client appears expedited, the script will go to the MONY/DISB screen and reads the MAXIS screen to see if the client has an EBT account open or not.

If the code is “N” then the following verbiage has been added to the case note “EBT Account is NOT open. Recipient is able to get initial card in the agency. Rapid Electronic Issuance (REI) can be used, but only to avoid an emergency issuance or to meet EXP criteria."

If the code is “Y” then the following verbiage has been added to the case note “EBT Account IS open. Recipient will be able to get a replacement card in the agency. Rapid Electronic Issuance (REI) with caution."