### PR TITLE
Updated verbiage on the SNAP E & T letter description

### DIFF
--- a/Script Files/MEMOS/MEMOS - MAIN MENU.vbs
+++ b/Script Files/MEMOS/MEMOS - MAIN MENU.vbs
@@ -75,7 +75,7 @@ BeginDialog MEMOS_scripts_main_menu_dialog, 0, 0, 451, 255, "Memos scripts main 
   Text 35, 165, 375, 10, "--- Sends the SNAP notice of missed interview (NOMI) letter, following rules set out in POLI/TEMP TE02.05.15."
   Text 65, 180, 355, 20, "--- Sends a MEMO informing client that they need to report information regarding the birth of their child, and/or pregnancy end date, within 10 days or their case may close."
   Text 75, 205, 340, 10, "--- NEW 08/2015!!! -- Sends a MEMO when a client reports significant change requiring additional action."
-  Text 80, 220, 300, 10, "--- Sends a MEMO informing client that they have an Employment and Training appointment."
+  Text 80, 220, 300, 10, "--- Sends a SPEC/LETR informing client that they have an Employment and Training appointment."
   ButtonGroup ButtonPressed
 EndDialog
 


### PR DESCRIPTION
from MEMO to SPEC/LETR.  I can't tell you how many people report that the script isn't working because they go to SPEC/MEMO instead of SPEC/WCOM to see the correspondence.