### PR TITLE
Many updates to CSR (see notes)

### DIFF
--- a/Script Files/NOTES/NOTES - CSR.vbs
+++ b/Script Files/NOTES/NOTES - CSR.vbs
@@ -69,83 +69,112 @@ BeginDialog case_number_dialog, 0, 0, 166, 205, "Case number dialog"
   Text 10, 10, 50, 10, "Case number:"
   Text 10, 30, 65, 10, "Footer month/year:"
   GroupBox 5, 45, 140, 30, "Programs recertifying"
-  Text 10, 140, 145, 25, "If you select "Is this an exempt IR", the case note will only read that the paperless IR was cleared (no case information listed)."
+  Text 10, 140, 145, 25, "If you select ''Is this an exempt IR'', the case note will only read that the paperless IR was cleared (no case information listed)."
   GroupBox 5, 125, 155, 75, "Exempt IR checkbox warning:"
   Text 10, 175, 140, 20, " If you are processing a CSR with SNAP, you should NOT check that option."
 EndDialog
 
-
-BeginDialog CSR_dialog, 0, 0, 451, 350, "CSR dialog"
+BeginDialog CSR_dialog01, 0, 0, 451, 225, "CSR dialog"
   EditBox 65, 15, 50, 15, CSR_datestamp
   DropListBox 170, 15, 75, 15, "select one..."+chr(9)+"complete"+chr(9)+"incomplete", CSR_status
   EditBox 40, 35, 280, 15, HH_comp
   EditBox 65, 55, 380, 15, earned_income
   EditBox 70, 75, 375, 15, unearned_income
-  EditBox 65, 95, 380, 15, notes_on_abawd
-  EditBox 40, 115, 405, 15, assets
-  EditBox 60, 135, 95, 15, SHEL_HEST
-  EditBox 220, 135, 95, 15, COEX_DCEX
-  EditBox 100, 155, 345, 15, FIAT_reasons
-  EditBox 50, 175, 395, 15, other_notes '11
-  EditBox 45, 195, 400, 15, changes
-  EditBox 60, 215, 385, 15, verifs_needed
-  EditBox 60, 235, 385, 15, actions_taken
-  EditBox 380, 255, 65, 15, worker_signature
-  CheckBox 190, 285, 110, 10, "Send forms to AREP?", sent_arep_checkbox
-  CheckBox 190, 300, 175, 10, "Check here to case note grant info from ELIG/FS.", grab_FS_info_checkbox
-  CheckBox 190, 315, 210, 10, "Check here if CSR and cash supplement were used as a HRF.", HRF_checkbox
-  CheckBox 190, 330, 120, 10, "Check here if an eDRS was sent.", eDRS_sent_checkbox
-  EditBox 60, 310, 90, 15, MAEPD_premium
-  CheckBox 10, 330, 65, 10, "Emailed MADE?", MADE_checkbox '21
+  EditBox 70, 95, 375, 15, notes_on_income
+  EditBox 65, 115, 380, 15, notes_on_abawd
+  EditBox 40, 135, 405, 15, assets
+  EditBox 60, 155, 95, 15, SHEL_HEST
+  EditBox 225, 155, 95, 15, COEX_DCEX
   ButtonGroup ButtonPressed
-    OkButton 340, 275, 50, 15
-    CancelButton 395, 275, 50, 15
+    OKButton 340, 205, 50, 15
+    CancelButton 395, 205, 50, 15
     PushButton 260, 15, 20, 10, "FS", ELIG_FS_button
     PushButton 280, 15, 20, 10, "HC", ELIG_HC_button
     PushButton 335, 15, 45, 10, "prev. panel", prev_panel_button
     PushButton 335, 25, 45, 10, "next panel", next_panel_button
     PushButton 395, 15, 45, 10, "prev. memb", prev_memb_button
     PushButton 395, 25, 45, 10, "next memb", next_memb_button
-    PushButton 5, 140, 25, 10, "SHEL/", SHEL_button '31
-    PushButton 30, 140, 25, 10, "HEST:", HEST_button
-    PushButton 165, 140, 25, 10, "COEX/", COEX_button
-    PushButton 190, 140, 25, 10, "DCEX:", DCEX_button
-    PushButton 10, 270, 25, 10, "BUSI", BUSI_button
-    PushButton 35, 270, 25, 10, "JOBS", JOBS_button
-    PushButton 35, 280, 25, 10, "UNEA", UNEA_button
-    PushButton 75, 270, 25, 10, "ACCT", ACCT_button
-    PushButton 100, 270, 25, 10, "CARS", CARS_button
-    PushButton 125, 270, 25, 10, "CASH", CASH_button '41
-    PushButton 150, 270, 25, 10, "OTHR", OTHR_button
-    PushButton 75, 280, 25, 10, "REST", REST_button
-    PushButton 100, 280, 25, 10, "SECU", SECU_button
-    PushButton 125, 280, 25, 10, "TRAN", TRAN_button
-    PushButton 190, 270, 25, 10, "MEMB", MEMB_button
-    PushButton 215, 270, 25, 10, "MEMI", MEMI_button
-    PushButton 240, 270, 25, 10, "REVW", REVW_button
-    PushButton 80, 330, 65, 10, "SIR mail", SIR_mail_button
+    PushButton 5, 160, 25, 10, "SHEL/", SHEL_button
+    PushButton 30, 160, 25, 10, "HEST:", HEST_button
+    PushButton 160, 160, 30, 10, "COEX/", COEX_button
+    PushButton 190, 160, 30, 10, "DCEX:", DCEX_button
+    PushButton 10, 190, 25, 10, "BUSI", BUSI_button
+    PushButton 35, 190, 25, 10, "JOBS", JOBS_button
+    PushButton 35, 200, 25, 10, "UNEA", UNEA_button
+    PushButton 75, 190, 25, 10, "ACCT", ACCT_button
+    PushButton 100, 190, 25, 10, "CARS", CARS_button
+    PushButton 125, 190, 25, 10, "CASH", CASH_button
+    PushButton 150, 190, 25, 10, "OTHR", OTHR_button
+    PushButton 75, 200, 25, 10, "REST", REST_button
+    PushButton 100, 200, 25, 10, "SECU", SECU_button
+    PushButton 125, 200, 25, 10, "TRAN", TRAN_button
+    PushButton 190, 190, 25, 10, "MEMB", MEMB_button
+    PushButton 215, 190, 25, 10, "MEMI", MEMI_button
+    PushButton 240, 190, 25, 10, "REVW", REVW_button
   GroupBox 255, 5, 50, 25, "ELIG panels:"
-  GroupBox 330, 5, 115, 35, "STAT-based navigation:"   '51
+  GroupBox 330, 5, 115, 35, "STAT-based navigation:"
   Text 5, 20, 55, 10, "CSR datestamp:"
   Text 125, 20, 40, 10, "CSR status:"
   Text 5, 40, 35, 10, "HH comp:"
   Text 5, 60, 55, 10, "Earned income:"
   Text 5, 80, 60, 10, "Unearned income:"
-  Text 5, 100, 60, 10, "Notes on WREG:"
-  Text 5, 120, 30, 10, "Assets:"
-  Text 5, 160, 95, 10, "FIAT reasons (if applicable):"
-  Text 5, 180, 40, 10, "Other notes:"
-  Text 5, 200, 35, 10, "Changes?:"
-  Text 5, 220, 50, 10, "Verifs needed:" '61
-  Text 5, 240, 50, 10, "Actions taken:"
-  GroupBox 5, 260, 175, 35, "Income and asset panels"
-  GroupBox 185, 260, 85, 25, "other STAT panels:"
-  Text 650, 650, 650, 650, spooky 'getting past 65 item limit
-  Text 315, 260, 65, 10, "Worker signature:"
-  GroupBox 5, 300, 150, 45, "If MA-EPD..."
-  Text 10, 315, 50, 10, "New premium:"
+  Text 5, 100, 60, 10, "Notes on Income:"
+  Text 5, 120, 60, 10, "Notes on WREG:"
+  Text 5, 140, 30, 10, "Assets:"
+  GroupBox 5, 180, 175, 35, "Income and asset panels"
+  GroupBox 185, 180, 85, 25, "other STAT panels:"
 EndDialog
 
+BeginDialog CSR_dialog02, 0, 0, 451, 260, "CSR dialog"
+  EditBox 100, 25, 150, 15, FIAT_reasons
+  EditBox 50, 45, 395, 15, other_notes
+  EditBox 45, 65, 400, 15, changes
+  EditBox 60, 85, 385, 15, verifs_needed
+  EditBox 60, 105, 385, 15, actions_taken
+  EditBox 380, 220, 65, 15, worker_signature
+  CheckBox 190, 155, 110, 10, "Send forms to AREP?", sent_arep_checkbox
+  CheckBox 190, 170, 175, 10, "Check here to case note grant info from ELIG/FS.", grab_FS_info_checkbox
+  CheckBox 190, 185, 210, 10, "Check here if CSR and cash supplement were used as a HRF.", HRF_checkbox
+  CheckBox 190, 200, 120, 10, "Check here if an eDRS was sent.", eDRS_sent_checkbox
+  EditBox 60, 180, 90, 15, MAEPD_premium
+  CheckBox 10, 200, 65, 10, "Emailed MADE?", MADE_checkbox
+  ButtonGroup ButtonPressed
+    PushButton 275, 245, 60, 10, "Previous", previous_button
+    OkButton 340, 240, 50, 15
+    CancelButton 395, 240, 50, 15
+    PushButton 260, 15, 20, 10, "FS", ELIG_FS_button
+    PushButton 280, 15, 20, 10, "HC", ELIG_HC_button
+    PushButton 335, 15, 45, 10, "prev. panel", prev_panel_button
+    PushButton 335, 25, 45, 10, "next panel", next_panel_button
+    PushButton 395, 15, 45, 10, "prev. memb", prev_memb_button
+    PushButton 395, 25, 45, 10, "next memb", next_memb_button
+    PushButton 10, 140, 25, 10, "BUSI", BUSI_button
+    PushButton 35, 140, 25, 10, "JOBS", JOBS_button
+    PushButton 35, 150, 25, 10, "UNEA", UNEA_button
+    PushButton 75, 140, 25, 10, "ACCT", ACCT_button
+    PushButton 100, 140, 25, 10, "CARS", CARS_button
+    PushButton 125, 140, 25, 10, "CASH", CASH_button
+    PushButton 150, 140, 25, 10, "OTHR", OTHR_button
+    PushButton 75, 150, 25, 10, "REST", REST_button
+    PushButton 100, 150, 25, 10, "SECU", SECU_button
+    PushButton 125, 150, 25, 10, "TRAN", TRAN_button
+    PushButton 190, 140, 25, 10, "MEMB", MEMB_button
+    PushButton 215, 140, 25, 10, "MEMI", MEMI_button
+    PushButton 240, 140, 25, 10, "REVW", REVW_button
+    PushButton 80, 200, 65, 10, "SIR mail", SIR_mail_button
+  Text 5, 30, 95, 10, "FIAT reasons (if applicable):"
+  Text 5, 50, 40, 10, "Other notes:"
+  Text 5, 70, 35, 10, "Changes?:"
+  Text 5, 90, 50, 10, "Verifs needed:"
+  Text 5, 110, 50, 10, "Actions taken:"
+  GroupBox 5, 130, 175, 35, "Income and asset panels"
+  GroupBox 185, 130, 85, 25, "other STAT panels:"
+  Text 315, 225, 65, 10, "Worker signature:"
+  GroupBox 5, 170, 150, 45, "If MA-EPD..."
+  Text 10, 185, 50, 10, "New premium:"
+  GroupBox 255, 5, 50, 25, "ELIG panels:"
+  GroupBox 330, 5, 115, 35, "STAT-based navigation:"
+EndDialog
 
 'VARIABLES WHICH NEED DECLARING------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 HH_memb_row = 5
@@ -230,31 +259,53 @@ if right(programs_recertifying, 1) = "," then programs_recertifying = left(progr
 CSR_month = footer_month & "/" & footer_year
 
 'Showing the case note dialog
-Do
+DO
 	Do
+		err_msg = ""
 		Do
-			Dialog CSR_dialog
-			cancel_confirmation
-			If ButtonPressed = SIR_mail_button then run "C:\Program Files\Internet Explorer\iexplore.exe https://www.dhssir.cty.dhs.state.mn.us/Pages/Default.aspx"
-		Loop until ButtonPressed <> no_cancel_button
-		MAXIS_dialog_navigation
-	LOOP until ButtonPressed = -1
-	If (earned_income = "" and unearned_income = "") or actions_taken = "" or CSR_datestamp = "" or worker_signature = "" or CSR_status = "select one..." then MsgBox "You need to fill in the datestamp, income, CSR status, and actions taken sections, as well as sign your case note. Check these items after pressing ''OK''."
-Loop until (earned_income <> "" or unearned_income <> "") and actions_taken <> "" and CSR_datestamp <> "" and worker_signature <> "" and CSR_status <> "select one..."
+			Do
+				Dialog CSR_dialog01
+				cancel_confirmation
+				If ButtonPressed = SIR_mail_button then run "C:\Program Files\Internet Explorer\iexplore.exe https://www.dhssir.cty.dhs.state.mn.us/Pages/Default.aspx"
+			Loop until ButtonPressed <> no_cancel_button
+			MAXIS_dialog_navigation
+		LOOP until ButtonPressed = -1
+		IF CSR_datestamp = "" THEN 														err_msg = err_msg & vbCr & "* Please enter the date the CSR was received."
+		IF CSR_status = "select one..." THEN 											err_msg = err_msg & vbCr & "* Please select the status of the CSR."
+		IF HH_comp = "" THEN 															err_msg = err_msg & vbCr & "* Please enter household composition information."
+		IF earned_income = "" AND unearned_income = "" AND notes_on_income = "" THEN 	err_msg = err_msg & vbCr & "* You must provide some information about income."
+		IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbCr & err_msg & vbCr & vbCr & "Please resolve for the script to continue." 
+	Loop until err_msg = ""
+	DO
+		DO
+			DO
+				Dialog CSR_dialog02
+				cancel_confirmation
+				IF ButtonPressed = SIR_mail_button THEN run "C:\Program Files\Internet Explorer\iexplore.exe https://www.dhssir.cty.dhs.state.mn.us/Pages/Default.aspx"
+			LOOP UNTIL ButtonPressed <> no_cancel_button
+			MAXIS_dialog_navigation
+		LOOP UNTIL ButtonPressed = -1 OR ButtonPressed = previous_button
+		err_msg = ""
+		IF actions_taken = "" THEN 		err_msg = err_msg & vbCr & "* Please indicate the actions you have taken."
+		IF worker_signature = "" THEN 	err_msg = err_msg & vbCr & "* Please sign your case note."
+		IF err_msg <> "" AND ButtonPressed = -1 THEN MsgBox "*** NOTICE!!! ***" & vbCr & err_msg & vbCr & vbCr & "Please resolve for the script to continue."
+	LOOP UNTIL err_msg = "" OR ButtonPressed = previous_button
+LOOP WHILE ButtonPressed = previous_button
 
-'grabbing information about elig/fs
-call navigate_to_MAXIS_screen("elig", "fs")
-EMReadScreen FSPR_check, 4, 3, 48
-If FSPR_check <> "FSPR" then
-	MsgBox "The script couldn't find ELIG/FS. It will now jump to case note."
-Else
-	EMWriteScreen "FSSM", 19, 70
-	transmit
-	EMReadScreen FSSM_line_01, 37, 13, 44
-	EMReadScreen FSSM_line_02, 37, 8, 3
-	EMReadScreen FSSM_line_03, 37, 10, 3
-End if
-
+IF grab_FS_info_checkbox = 1 THEN 
+	'grabbing information about elig/fs
+	call navigate_to_MAXIS_screen("elig", "fs")
+	EMReadScreen FSPR_check, 4, 3, 48
+	If FSPR_check <> "FSPR" then
+		MsgBox "The script couldn't find ELIG/FS. It will now jump to case note."
+	Else
+		EMWriteScreen "FSSM", 19, 70
+		transmit
+		EMReadScreen FSSM_line_01, 37, 13, 44
+		EMReadScreen FSSM_line_02, 37, 8, 3
+		EMReadScreen FSSM_line_03, 37, 10, 3
+	End if
+END IF
 
 'Writing the case note to MAXIS----------------------------------------------------------------------------------------------------
 start_a_blank_CASE_NOTE
@@ -278,7 +329,7 @@ call write_bullet_and_variable_in_case_note("Actions taken", actions_taken)
 call write_bullet_and_variable_in_case_note("MA-EPD premium", MAEPD_premium)
 If MADE_checkbox = checked then call write_variable_in_case_note("* Emailed MADE through DHS-SIR.")
 call write_variable_in_case_note("---")
-If FSPR_check = "FSPR" then
+If grab_FS_info_checkbox = 1 AND FSPR_check = "FSPR" then
 	call write_variable_in_case_note("   " & FSSM_line_01)
 	call write_variable_in_case_note("   " & FSSM_line_02)
 	call write_variable_in_case_note("   " & FSSM_line_03)


### PR DESCRIPTION
* Split dialog into 2 dialogs (we were hitting the 65 object limit)
* Added err_msg handling around mandatory dialog fields (CSR_datestamp, CSR_status, HH_comp, earned_income-unearned_income-notes_on_income, actions_taken, worker_signature)
* Added previous button to second dialog to allow users to review work on page 1.