### PR TITLE
Fix for footer month issue

### DIFF
--- a/Script Files/NOTES/NOTES - HC RENEWAL.vbs
+++ b/Script Files/NOTES/NOTES - HC RENEWAL.vbs
@@ -154,6 +154,8 @@ If row <> 0 then
 	If row <> 0 then footer_year = MAXIS_footer_year
 End if
 
+footer_month = CStr(footer_month)
+
 'Showing the case number dialog 
 Do
 	Dialog case_number_and_footer_month_dialog


### PR DESCRIPTION
#561  CAF seems to be pulling footer months, CSR also autofills, as does CAR. HCAPP was fixed in previous version. 