### PR TITLE
writing the worker number

### DIFF
--- a/Script Files/BULK/BULK - REPT-PND2 LIST.vbs
+++ b/Script Files/BULK/BULK - REPT-PND2 LIST.vbs
@@ -166,7 +166,7 @@ End if
 For each worker in worker_array
 	back_to_self	'Does this to prevent "ghosting" where the old info shows up on the new screen for some reason
 	Call navigate_to_MAXIS_screen("rept", "pnd2")
-	EMWriteScreen worker, 21, 17
+	EMWriteScreen right(worker, 3), 21, 17
 	transmit
 
 	'Skips workers with no info


### PR DESCRIPTION
The script is making sure to write the worker number in the correct place. Works for both agency-wide and individual look ups.