### PR TITLE
Simplifying auto-fill of benefit year

### DIFF
--- a/Script Files/NOTES/NOTES - HCAPP.vbs
+++ b/Script Files/NOTES/NOTES - HCAPP.vbs
@@ -51,9 +51,7 @@ END IF
 
 footer_month = datepart("m", date)
 If len(footer_month) = 1 then footer_month = "0" & footer_month
-footer_year = datepart("yyyy", next_month)
-footer_year = "" & footer_year - 2000
-
+footer_year = right(datepart("yyyy", next_month), 2)
 
 'DIALOGS-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 BeginDialog case_number_and_footer_month_dialog, 0, 0, 161, 65, "Case number and footer month"


### PR DESCRIPTION
The script was subtracting 2000 from the benefit year when all it needed to do was read the right 2 of the benefit year. This was generating a result of benefit_year = -101.

Resolves issue #1151 