### PR TITLE
next_month not defined, adjusted for date

### DIFF
--- a/Script Files/NOTES/NOTES - HCAPP.vbs
+++ b/Script Files/NOTES/NOTES - HCAPP.vbs
@@ -51,7 +51,7 @@ END IF
 
 footer_month = datepart("m", date)
 If len(footer_month) = 1 then footer_month = "0" & footer_month
-footer_year = right(datepart("yyyy", next_month), 2)
+footer_year = right(datepart("yyyy", date), 2)
 
 'DIALOGS-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 BeginDialog case_number_and_footer_month_dialog, 0, 0, 161, 65, "Case number and footer month"


### PR DESCRIPTION
footer_year was being determined from an unknown variable (which is why it was originally delivering footer_month = -101

I didn't notice it in my haste. Now, footer_year is determined from date