### PR TITLE
reinstating multicounty functionality

### DIFF
--- a/Script Files/BULK/BULK - REPT-ACTV LIST.vbs
+++ b/Script Files/BULK/BULK - REPT-ACTV LIST.vbs
@@ -70,6 +70,9 @@ EndDialog
 
 'THE SCRIPT-------------------------------------------------------------------------
 
+'Determining specific county for multicounty agencies...
+CALL worker_county_code_determination(worker_county_code, two_digit_county_code)
+
 'Connects to BlueZone
 EMConnect ""
 


### PR DESCRIPTION
this script would not work for multicounty agencies. now it should. I inserted the function that does stuff to reduce multicounty to a single 2-digimon county code