### PR TITLE
several fixes to NOTES-APPROVED PROGRAMS (see below)

### DIFF
--- a/Script Files/NOTES/NOTES - APPROVED PROGRAMS.vbs
+++ b/Script Files/NOTES/NOTES - APPROVED PROGRAMS.vbs
@@ -49,12 +49,12 @@ END IF
 'END FUNCTIONS LIBRARY BLOCK================================================================================================
 
 'DIALOGS----------------------------------------------------------------------------------------------------
-BeginDialog benefits_approved, 0, 0, 271, 260, "Benefits Approved"
+BeginDialog benefits_approved, 0, 0, 271, 280, "Benefits Approved"
   CheckBox 80, 5, 30, 10, "SNAP", snap_approved_check
   CheckBox 115, 5, 30, 10, "Cash", cash_approved_check
   CheckBox 150, 5, 50, 10, "Health Care", hc_approved_check
   CheckBox 210, 5, 50, 10, "Emergency", emer_approved_check
-  EditBox 55, 20, 60, 15, case_number
+  EditBox 60, 20, 55, 15, case_number
   ComboBox 180, 20, 80, 15, "Initial"+chr(9)+"Renewal"+chr(9)+"Recertification"+chr(9)+"Change"+chr(9)+"Reinstate", type_of_approval
   EditBox 115, 45, 150, 15, benefit_breakdown
   CheckBox 5, 65, 255, 10, "Check here to have the script autofill the SNAP approval.", autofill_snap_check
@@ -70,12 +70,13 @@ BeginDialog benefits_approved, 0, 0, 271, 260, "Benefits Approved"
   EditBox 55, 145, 210, 15, other_notes
   EditBox 75, 165, 190, 15, programs_pending
   EditBox 55, 185, 210, 15, docs_needed
-  CheckBox 10, 205, 235, 10, "Check here if child support disregard was applied to MFIP/DWP case", CASH_WCOM_checkbox
-  CheckBox 10, 220, 125, 10, "Check here if the case was FIATed", FIAT_checkbox
-  EditBox 75, 235, 80, 15, worker_signature
+  'CheckBox 10, 210, 250, 10, "Check here if SNAP was approved expedited with postponed verifications.", postponed_verif_check
+  CheckBox 10, 225, 235, 10, "Check here if child support disregard was applied to MFIP/DWP case", CASH_WCOM_checkbox
+  CheckBox 10, 240, 125, 10, "Check here if the case was FIATed", FIAT_checkbox
+  EditBox 75, 255, 80, 15, worker_signature
   ButtonGroup ButtonPressed
-    OkButton 160, 235, 50, 15
-    CancelButton 215, 235, 50, 15
+    OkButton 160, 255, 50, 15
+    CancelButton 215, 255, 50, 15
   Text 5, 25, 50, 10, "Case Number:"
   Text 5, 40, 110, 20, "Benefit Breakdown (Issuance/Spenddown/Premium):"
   Text 10, 85, 130, 10, "Select SNAP approval range (MM YY)..."
@@ -85,7 +86,7 @@ BeginDialog benefits_approved, 0, 0, 271, 260, "Benefits Approved"
   Text 5, 150, 45, 10, "Other Notes:"
   Text 5, 170, 70, 10, "Pending Program(s):"
   Text 5, 190, 50, 10, "Verifs Needed:"
-  Text 15, 240, 60, 10, "Worker Signature: "
+  Text 10, 260, 60, 10, "Worker Signature: "
   Text 120, 25, 60, 10, "Type of Approval:"
   Text 5, 5, 70, 10, "Approved Programs:"
 EndDialog
@@ -119,35 +120,34 @@ cash_end_mo = bene_month
 cash_end_yr = bene_year
 
 'Displays the dialog and navigates to case note
-   Do
-     Dialog benefits_approved
-     cancel_confirmation
-IF snap_approved_check = 0 AND autofill_snap_check = checked THEN MsgBox "You checked to have the SNAP results autofilled but did not select that SNAP was approved. Please reconsider your selections and try again."
-IF cash_approved_check = 0 AND autofill_cash_check = checked THEN MsgBox "You checked to have the CASH results autofilled but did not select that CASH was approved. Please reconsider your selections and try again."
-     If case_number = "" then MsgBox "You must have a case number to continue!"
-If worker_signature = "" then Msgbox "Please sign your case note"
-
-IF autofill_cash_check = checked AND cash_approved_check = checked THEN
-	'Calculates the number of benefit months the worker is trying to case note.
-	cash_start = cdate(cash_start_mo & "/01/" & cash_start_yr)
-	cash_end = cdate(cash_end_mo & "/01/" & cash_end_yr)
-	IF datediff("M", date, cash_start) > 1 THEN MsgBox "Your CASH start month is invalid. You cannot case note eligibility results from more than 1 month into the future. Please change your months."
-	IF datediff("M", date, cash_end) > 1 THEN MsgBox "Your CASH end month is invalid. You cannot case note eligibility results from more than 1 month into the future. Please change your months."
-	IF datediff("M", cash_start, cash_end) < 0 THEN MsgBox "Please double check your CASH date range. Your start month cannot be later than your end month."
-END IF
-
-IF autofill_snap_check = checked AND snap_approved_check = checked THEN 
-	'Calculates the number of benefit months the worker is trying to case note.
-	snap_start = cdate(snap_start_mo & "/01/" & snap_start_yr)
-	snap_end = cdate(snap_end_mo & "/01/" & snap_end_yr)
-	IF datediff("M", date, snap_start) > 1 THEN MsgBox "Your SNAP start month is invalid. You cannot case note eligibility results from more than 1 month into the future. Please change your months."
-	IF datediff("M", date, snap_end) > 1 THEN MsgBox "Your SNAP end month is invalid. You cannot case note eligibility results from more than 1 month into the future. Please change your months."
-	IF datediff("M", snap_start, snap_end) < 0 THEN MsgBox "Please double check your SNAP date range. Your start month cannot be later than your end month."
-END IF
-Loop until case_number <> "" AND _
-worker_signature <> "" AND _
-((snap_approved_check = checked AND autofill_snap_check = checked AND (datediff("M", snap_start, snap_end) >= 0) AND (datediff("M", date, snap_start) < 2) AND (datediff("M", date, snap_end) < 2)) OR (autofill_snap_check = 0)) AND _
-((cash_approved_check = checked AND autofill_cash_check = checked AND (datediff("M", cash_start, cash_end) >= 0) AND (datediff("M", date, cash_start) < 2) AND (datediff("M", date, cash_end) < 2)) OR (autofill_cash_check = 0))
+Do
+	'Adding err_msg handling
+	err_msg = ""
+	Dialog benefits_approved
+	cancel_confirmation
+		'Enforcing mandatory fields
+		If case_number = "" then err_msg = err_msg & vbCr & "* Please enter a case number."
+		IF snap_approved_check = 0 AND autofill_snap_check = checked THEN err_msg = err_msg & vbCr & "* You checked to have the SNAP results autofilled but did not select that SNAP was approved. Please reconsider your selections and try again."
+		IF cash_approved_check = 0 AND autofill_cash_check = checked THEN err_msg = err_msg & vbCr & "* You checked to have the CASH results autofilled but did not select that CASH was approved. Please reconsider your selections and try again."
+		IF autofill_cash_check = checked AND cash_approved_check = checked THEN
+			'Calculates the number of benefit months the worker is trying to case note.
+			cash_start = cdate(cash_start_mo & "/01/" & cash_start_yr)
+			cash_end = cdate(cash_end_mo & "/01/" & cash_end_yr)
+			IF datediff("M", date, cash_start) > 1 THEN err_msg = err_msg & vbCr & "* Your CASH start month is invalid. You cannot case note eligibility results from more than 1 month into the future. Please change your months."
+			IF datediff("M", date, cash_end) > 1 THEN err_msg = err_msg & vbCr & "* Your CASH end month is invalid. You cannot case note eligibility results from more than 1 month into the future. Please change your months."
+			IF datediff("M", cash_start, cash_end) < 0 THEN err_msg = err_msg & vbCr & "* Please double check your CASH date range. Your start month cannot be later than your end month."
+		END IF	
+		IF autofill_snap_check = checked AND snap_approved_check = checked THEN 
+			'Calculates the number of benefit months the worker is trying to case note.
+			snap_start = cdate(snap_start_mo & "/01/" & snap_start_yr)
+			snap_end = cdate(snap_end_mo & "/01/" & snap_end_yr)
+			IF datediff("M", date, snap_start) > 1 THEN err_msg = err_msg & vbCr & "* Your SNAP start month is invalid. You cannot case note eligibility results from more than 1 month into the future. Please change your months."
+			IF datediff("M", date, snap_end) > 1 THEN err_msg = err_msg & vbCr & "* Your SNAP end month is invalid. You cannot case note eligibility results from more than 1 month into the future. Please change your months."
+			IF datediff("M", snap_start, snap_end) < 0 THEN err_msg = err_msg & vbCr & "* Please double check your SNAP date range. Your start month cannot be later than your end month."
+		END IF
+		IF worker_signature = "" then err_msg = err_msg & vbCr & "* Please sign your case note."
+		IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbCr & err_msg & vbCr & vbCr & "Please resolve for the script to continue."
+Loop until err_msg = ""
 
 'checking for an active MAXIS session
 Call check_for_MAXIS(FALSE)  
@@ -293,7 +293,7 @@ IF autofill_cash_check = checked THEN
 						EMReadScreen current_cash_bene_yr, 2, 20, 58
 						current_cash_month = current_cash_bene_mo & "/01/" & current_cash_bene_yr
 						'Determining the benefit month so that script knows whether or not to be looking for the MFIP housing grant.
-						'If the benefit month is 07/15 or later, it will read the housing grant...
+						'If the benefit month is 10/15 or later, it will read the housing grant...
 						IF DateDiff("D", mfip_housing_start_date, current_cash_month) >= 0 THEN 
 							EMReadScreen mfip_bene_cash_amt, 8, 14, 73
 							EMReadScreen mfip_bene_food_amt, 8, 15, 73
@@ -323,7 +323,7 @@ IF autofill_cash_check = checked THEN
 						EMReadScreen current_cash_bene_yr, 2, 20, 58
 						current_cash_month = current_cash_bene_mo & "/01/" & current_cash_bene_yr
 						'Determining the benefit month so that script knows whether or not to be looking for the MFIP housing grant.
-						'If the benefit month is 07/15 or later, it will read the housing grant...
+						'If the benefit month is 10/15 or later, it will read the housing grant...
 						IF DateDiff("D", mfip_housing_start_date, current_cash_month) >= 0 THEN 
 							EMReadScreen mfip_bene_cash_amt, 8, 14, 73
 							EMReadScreen mfip_bene_food_amt, 8, 15, 73
@@ -451,34 +451,45 @@ END IF
 
 
 'updates WCOM with notice requirements if MFIP or DWP child support income disregarded in the budget
-read_row = 7
-
 If CASH_WCOM_checkbox = checked THEN 
 	Call navigate_to_MAXIS_screen ("SPEC", "WCOM")
-	EMReadscreen CASH_check, 2, read_row, 26  'checking to make sure that notice is for MFIP or DWP
-	EMReadScreen Print_status_check, 7, read_row, 71 'checking to see if notice is in 'waiting status'
-	'checking program type and if it's a notice that is in waiting status (waiting status will make it editable)
-	If(CASH_check = "MF" AND Print_status_check = "Waiting") OR (CASH_check = "DW" AND Print_status_check = "Waiting") THEN 
-		EMSetcursor read_row, 13
-		EMSendKey "x"
-		Transmit
-		PF9
-		EMSetCursor 03, 15
-		'WCOM required by workers upon approval of MFIP and DWP cases with child support FIAT'd out of the budget
-		Call write_variable_in_SPEC_MEMO("************************************************************")
-		Call write_variable_in_SPEC_MEMO("")
-		Call write_variable_in_SPEC_MEMO("Starting July 1, 2015 a new law begins that allows us to not count some of the child support you get when determining your monthly MFIP/DWP benefit amount:")
-		Call write_variable_in_SPEC_MEMO("")
-		Call write_variable_in_SPEC_MEMO("* $100 for an assistance unit with one child")
-		Call write_variable_in_SPEC_MEMO("* $200 for an assistance unit with two or more children")
-		Call write_variable_in_SPEC_MEMO("")
-		Call write_variable_in_SPEC_MEMO("Because of this change, you may see an increase in your benefit amount.")
-		Call write_variable_in_SPEC_MEMO("************************************************************")
-		PF4
-		PF3
-	ELSE 
-		Msgbox "There is not a pending notice for this cash case. The script was unable to update your notice."
-	END if
+	read_row = 7
+	WCOM_to_notice = false
+	WCOM_error_message = ""
+	DO
+		EMReadscreen CASH_check, 2, read_row, 26  'checking to make sure that notice is for MFIP or DWP
+		EMReadScreen Print_status_check, 7, read_row, 71 'checking to see if notice is in 'waiting status'
+		'checking program type and if it's a notice that is in waiting status (waiting status will make it editable)
+		If(CASH_check = "MF" AND Print_status_check = "Waiting") OR (CASH_check = "DW" AND Print_status_check = "Waiting") THEN 
+			EMSetcursor read_row, 13
+			EMSendKey "x"
+			Transmit
+			PF9
+			EMSetCursor 03, 15
+			'WCOM required by workers upon approval of MFIP and DWP cases with child support FIAT'd out of the budget
+			Call write_variable_in_SPEC_MEMO("************************************************************")
+			Call write_variable_in_SPEC_MEMO("")
+			Call write_variable_in_SPEC_MEMO("Starting October 1, 2015 a new law begins that allows us to not count some of the child support you get when determining your monthly MFIP/DWP benefit amount:")
+			Call write_variable_in_SPEC_MEMO("")
+			Call write_variable_in_SPEC_MEMO("* $100 for an assistance unit with one child")
+			Call write_variable_in_SPEC_MEMO("* $200 for an assistance unit with two or more children")
+			Call write_variable_in_SPEC_MEMO("")
+			Call write_variable_in_SPEC_MEMO("Because of this change, you may see an increase in your benefit amount.")
+			Call write_variable_in_SPEC_MEMO("************************************************************")
+			WCOM_to_notice = true
+			PF4
+			PF3
+		ELSEIF ((CASH_check = "MF" OR CASH_check = "DW") AND print_status_check <> "Waiting") OR (CASH_check <> "MF" AND CASH_check <> "DW") THEN
+			read_row = read_row + 1
+			IF read_row = 18 THEN 
+				read_row = 7
+				PF8
+			END IF
+		ELSEIF CASH_check = "  " THEN 
+			IF read_row <> 18 THEN EXIT DO
+		END IF
+	LOOP UNTIL WCOM_to_notice = True OR (CASH_check = "  " AND read_row <> 18)
+	IF WCOM_to_notice = False THEN Msgbox "There is not a pending notice for this cash case. The script was unable to update your notice."
 END If
 
 cash_approval_array = trim(cash_approval_array)
@@ -487,13 +498,19 @@ cash_approval_array = split(cash_approval_array)
 
 'Case notes----------------------------------------------------------------------------------------------------
 call start_a_blank_CASE_NOTE
-IF snap_approved_check = checked THEN approved_programs = approved_programs & "SNAP/"
+IF snap_approved_check = checked THEN 
+	'IF postponed_verif_check = checked THEN 
+	'	approved_programs = approved_programs & "EXPEDITED SNAP/"
+	'ELSE
+		approved_programs = approved_programs & "SNAP/"
+	'END IF
+END IF
 IF hc_approved_check = checked THEN approved_programs = approved_programs & "HC/"
 IF cash_approved_check = checked THEN approved_programs = approved_programs & "CASH/"
 IF emer_approved_check = checked THEN approved_programs = approved_programs & "EMER/"
 EMSendKey "---Approved " & approved_programs & "<backspace>" & " " & type_of_approval & "---" & "<newline>"
+IF postponed_verif_check = checked THEN write_variable_in_CASE_NOTE("**EXPEDITED SNAP APPROVED BUT CASE HAS POSTPONED VERIFICATIONS.**")
 IF benefit_breakdown <> "" THEN call write_bullet_and_variable_in_case_note("Benefit Breakdown", benefit_breakdown)
-
 IF autofill_snap_check = checked THEN
 	FOR EACH snap_approval_result in snap_approval_array
 		bene_amount = left(snap_approval_result, 4)
@@ -545,7 +562,10 @@ IF autofill_cash_check = checked THEN
 		END IF
 	NEXT
 END IF
-IF CASH_WCOM_checkbox = checked THEN call write_variable_in_CASE_NOTE(" * A WCOM for the CS disregard FIAT as been entered")
+IF CASH_WCOM_checkbox = checked THEN 
+	CALL write_variable_in_CASE_NOTE("* CS Disregard applied.")
+	IF WCOM_to_notice = TRUE THEN call write_variable_in_CASE_NOTE("* A WCOM for the CS disregard FIAT has been entered.")
+END IF
 IF FIAT_checkbox = 1 THEN Call write_variable_in_CASE_NOTE ("* This case has been FIATed.")
 IF other_notes <> "" THEN call write_bullet_and_variable_in_CASE_NOTE("Approval Notes", other_notes)
 IF programs_pending <> "" THEN call write_bullet_and_variable_in_CASE_NOTE("Programs Pending", programs_pending)


### PR DESCRIPTION
This update includes the following fixes, addressing issues #1217 and #1220.
1. err_msg handling around dialog (Operation Wind Tunnel)
2. Updated verbiage in notice to reflect October start date for CS Disregard (rather than July) and also removing typo.
3. Added do...loop around search for appropriate WCOM when user selects to case note that the CS disregard verbiage should be added to notice.
4. Updated case note verbiage to case note only when script actually updates a notice (currently, it is case noting that the cs disregard verbiage was added to the notice even if the script did not add one...there are instances when a new notice is not generated).