### PR TITLE
Bug fix/reverting code

### DIFF
--- a/Script Files/NOTES/NOTES - EXPEDITED SCREENING.vbs
+++ b/Script Files/NOTES/NOTES - EXPEDITED SCREENING.vbs
@@ -149,25 +149,37 @@ IF expedited_status = "client appears expedited" THEN
 END IF 
 
 'THE CASE NOTE----------------------------------------------------------------------------------------------------
-Call start_a_blank_CASE_NOTE
-Call write_variable_in_CASE_NOTE("Received " & application_type & ", " & expedited_status)
-call write_variable_in_CASE_NOTE("---")
-call write_variable_in_CASE_NOTE("     CAF 1 income claimed this month: $" & income)
-call write_variable_in_CASE_NOTE("         CAF 1 liquid assets claimed: $" & assets)
-call write_variable_in_CASE_NOTE("         CAF 1 rent/mortgage claimed: $" & rent)
-call write_variable_in_CASE_NOTE("        Utilities (amt/HEST claimed): $" & utilities)
-call write_variable_in_CASE_NOTE("---")
-If has_DISQ = True then call write_variable_in_CASE_NOTE("A DISQ panel exists for someone on this case.")
-If has_DISQ = False then call write_variable_in_CASE_NOTE("No DISQ panels were found for this case.")
-If expedited_status = "client appears expedited" AND EBT_account_status = "Y" then call write_variable_in_CASE_NOTE("* EBT Account IS open.  Recipient will NOT be able to get a replacement card in the agency.  Rapid Electronic Issuance (REI) with caution.")
-If expedited_status = "client appears expedited" AND EBT_account_status = "N" then call write_variable_in_CASE_NOTE("* EBT Account is NOT open.  Recipient is able to get initial card in the agency.  Rapid Electronic Issuance (REI) can be used, but only to avoid an emergency issuance or to meet EXP criteria.")
-call write_variable_in_CASE_NOTE("---")
-call write_variable_in_CASE_NOTE(worker_signature)
-If expedited_status = "client appears expedited" then
-	MsgBox "This client appears expedited. A same day interview needs to be offered."
-End if
-If expedited_status = "client does not appear expedited" then
-	MsgBox "This client does not appear expedited. A same day interview does not need to be offered."
-End if
-
+	call navigate_to_screen("case", "note")
+	PF9
+	
+	EMReadScreen case_note_check, 17, 2, 33
+	EMReadScreen mode_check, 1, 20, 09
+	If case_note_check <> "Case Notes (NOTE)" or mode_check <> "A" then    'this will account for those cases when the script is run on an out of county case.
+		msgbox "The script can't open a case note. You may be in inquiry or entered a case number that is in another county." &_
+		vbNewLine & vbNewLine & "This result for this case is " & expedited_status & vbNewLine & vbNewLine & "Please run the script again if you were in inquiry to add a case note."
+		script_end_procedure("")
+	else	
+		'Body of the case note 
+		Call write_variable_in_CASE_NOTE("Received " & application_type & ", " & expedited_status)
+		call write_variable_in_CASE_NOTE("---")
+		call write_variable_in_CASE_NOTE("     CAF 1 income claimed this month: $" & income)
+		call write_variable_in_CASE_NOTE("         CAF 1 liquid assets claimed: $" & assets)
+		call write_variable_in_CASE_NOTE("         CAF 1 rent/mortgage claimed: $" & rent)
+		call write_variable_in_CASE_NOTE("        Utilities (amt/HEST claimed): $" & utilities)
+		call write_variable_in_CASE_NOTE("---")
+		If has_DISQ = True then call write_variable_in_CASE_NOTE("A DISQ panel exists for someone on this case.")
+		If has_DISQ = False then call write_variable_in_CASE_NOTE("No DISQ panels were found for this case.")
+		If expedited_status = "client appears expedited" AND EBT_account_status = "Y" then call write_variable_in_CASE_NOTE("* EBT Account IS open.  Recipient will NOT be able to get a replacement card in the agency.  Rapid Electronic Issuance (REI) with caution.")
+		If expedited_status = "client appears expedited" AND EBT_account_status = "N" then call write_variable_in_CASE_NOTE("* EBT Account is NOT open.  Recipient is able to get initial card in the agency.  Rapid Electronic Issuance (REI) can be used, but only to avoid an emergency issuance or to meet EXP criteria.")
+		call write_variable_in_CASE_NOTE("---")
+		call write_variable_in_CASE_NOTE(worker_signature)
+		If expedited_status = "client appears expedited" then
+			MsgBox "This client appears expedited. A same day interview needs to be offered."
+		End if
+		If expedited_status = "client does not appear expedited" then
+			MsgBox "This client does not appear expedited. A same day interview does not need to be offered."
+		End if
+	End if
 script_end_procedure("")
+
+


### PR DESCRIPTION
Op Doubtfire replaced some code that was in place to prevent an infinite loop that start_a_blank_case_note causes when someone uses an incorrect case number or out of county case number. Took code from #967 and reincorporated it with recent enhancements. 

BLIP: Expedited screening tool can once again be used on out of county cases or cases without a case number (enter 1 as case number if client doesn't have case.)

fixes issue #1273