### PR TITLE
Fixing cancel_confirmation bug

### DIFF
--- a/Script Files/DAIL/DAIL - NEW HIRE.vbs
+++ b/Script Files/DAIL/DAIL - NEW HIRE.vbs
@@ -170,9 +170,15 @@ TIKL_checkbox = checked
 HH_memb_row = 5 
 
 'Show dialog
-Dialog new_HIRE_dialog
-MAXIS_dialog_navigation
-cancel_confirmation
+Do
+	Dialog new_HIRE_dialog
+	cancel_confirmation
+	MAXIS_dialog_navigation
+Loop until ButtonPressed = -1
+
+'Checking to see if 5 jobs already exist. If so worker will need to manually delete one first. 
+EMReadScreen jobs_total_panel_count, 1, 2, 78
+IF create_JOBS_checkbox = checked AND jobs_total_panel_count = "5" THEN script_end_procedure("This client has 5 jobs panels already. Please review and delete and unneeded panels if you want the script to add a new one.")
 
 'If new job is known, script ends.
 If job_known_checkbox = checked then script_end_procedure("The script will stop as this job is known.")


### PR DESCRIPTION

BLIP: Cancelling the script would lead to an infinite loop because of MAXIS_dialog_navigation function. Added a do/loop and reordered functions so they work in tandem.

#1354