### PR TITLE
variable to resize dialog changed from 45 to 65

### DIFF
--- a/Script Files/NOTES/NOTES - CLOSED PROGRAMS.vbs
+++ b/Script Files/NOTES/NOTES - CLOSED PROGRAMS.vbs
@@ -19,7 +19,7 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 			Set fso = CreateObject("Scripting.FileSystemObject")	'Creates an FSO
 			Execute req.responseText								'Executes the script code
 		ELSE														'Error message, tells user to try to reach github.com, otherwise instructs to contact Veronica with details (and stops script).
-			MsgBox 	"Something has gone wrong. The code stored on GitHub was not able to be reached." & vbCr &_ 
+			MsgBox 	"Something has gone wrong. The code stored on GitHub was not able to be reached." & vbCr &_
 					vbCr & _
 					"Before contacting Veronica Cary, please check to make sure you can load the main page at www.GitHub.com." & vbCr &_
 					vbCr & _
@@ -30,7 +30,7 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 					vbTab & vbTab & "responsible for network issues." & vbCr &_
 					vbTab & "- The URL indicated below (a screenshot should suffice)." & vbCr &_
 					vbCr & _
-					"Veronica will work with your IT department to try and solve this issue, if needed." & vbCr &_ 
+					"Veronica will work with your IT department to try and solve this issue, if needed." & vbCr &_
 					vbCr &_
 					"URL: " & FuncLib_URL
 					script_end_procedure("Script ended due to error connecting to GitHub.")
@@ -47,7 +47,7 @@ END IF
 'END FUNCTIONS LIBRARY BLOCK================================================================================================
 
 'VARIABLE REQUIRED TO RESIZE DIALOG BASED ON A GLOBAL VARIABLE IN FUNCTIONS FILE
-If case_noting_intake_dates = False then dialog_shrink_amt = 45
+If case_noting_intake_dates = False then dialog_shrink_amt = 65
 
 'THE DIALOG----------------------------------------------------------------------------------------------------
 BeginDialog closed_dialog, 0, 0, 421, 240 - dialog_shrink_amt, "Closed progs dialog"
@@ -96,7 +96,7 @@ HC_check = 0
 call MAXIS_case_number_finder(case_number)
 
 
-'Dialog starts. Checks for MAXIS, includes nav button for SPEC/WCOM, validates the date of closure, confirms that date 
+'Dialog starts. Checks for MAXIS, includes nav button for SPEC/WCOM, validates the date of closure, confirms that date
 '    of closure is last day of a month, checks that a program was selected for closure, and navigates to CASE/NOTE.
 DO
 	DO
@@ -136,7 +136,7 @@ End if
 'For HC, the client can turn in a HC ER before the end of the next month, or turn in a HCAPP anytime. Either way it's just treated as a new app.
 If HC_check = 1 then
   progs_closed = progs_closed & "HC/"
-  If HC_ER_check = 1 then 
+  If HC_ER_check = 1 then
     HC_last_REIN_date = closure_date 'This will force the HC_last_REIN_date variable to show the closure date, in case a SNAP CSR messes with the variable. HC ERs are always treated like a new application if turned in late.
     HC_followup_text = ", after which a new HC renewal or HCAPP is required. A new HCAPP is required after " & closure_month_last_day & "."
   End if


### PR DESCRIPTION
With the shrinkage at 45 the information of the bottom was getting cut
off. 65 covers the entire information message at the bottom (which is
necessary if it's not an intake case noting agency).

BLIP: Resized the dialog box for agencies that do not case note intake dates to not display the partial CM reference. 

resolves #1385 