### PR TITLE
Adding access to DAIL - ABAWD FSET EXEMPTION CHECK

### DIFF
--- a/Script Files/DAIL/DAIL - DAIL SCRUBBER.vbs
+++ b/Script Files/DAIL/DAIL - DAIL SCRUBBER.vbs
@@ -123,5 +123,9 @@ If SCHL_check = "STUDENT INCOME HAS ENDED - REVIEW FS AND/OR HC RESULTS/APP" the
 EMReadScreen TPQY_check, 31, 6, 30
 If TPQY_check = "TPQY RESPONSE RECEIVED FROM SSA" then call run_from_GitHub(script_repository & "DAIL/DAIL - TPQY RESPONSE.vbs")
 
+'FS Eligibility Ending for ABAWD
+EMReadScreen ABAWD_elig_end, 32, 6, 20
+IF ABAWD_elig_end = "FS ABAWD ELIGIBILITY HAS EXPIRED" THEN CALL run_from_GitHub(script_repository & "DAIL/DAIL - ABAWD FSET EXEMPTION CHECK.vbs")
+
 'NOW IF NO SCRIPT HAS BEEN WRITTEN FOR IT, THE DAIL SCRUBBER STOPS AND GENERATES A MESSAGE TO THE WORKER.----------------------------------------------------------------------------------------------------
 script_end_procedure("You are not on a supported DAIL message. The script will now stop. " & vbNewLine & vbNewLine & "The message reads: " & full_message)


### PR DESCRIPTION
Reading for "FS ABAWD ELIGIBILITY HAS EXPIRED" and running DAIL - ABAWD FSET EXEMPTION DOUBLE CHECK.vbs when it finds it.

In RE: #1231 

BLIP: This modification expands the DAIL scrubber to double check cases closing for ABAWD months for a possible exemption coded in MAXIS.