### PR TITLE
Bug fix, PESE not getting cleared #1505

### DIFF
--- a/Script Files/DAIL/DAIL - CSES PROCESSING.vbs
+++ b/Script Files/DAIL/DAIL - CSES PROCESSING.vbs
@@ -777,6 +777,7 @@ EndDialog
 
   current_SSN_with_spaces = ObjExcel.Cells(excel_row, 9).Value
   current_SSN = replace(ObjExcel.Cells(excel_row, 9).Value, " ", "")
+  EMWriteScreen "                 ", 4, 20
   EMWriteScreen "            ", 5, 20
   EMWriteScreen "            ", 6, 20
   EMWriteScreen "   ", 7, 20
@@ -789,8 +790,9 @@ EndDialog
   EMWriteScreen "N", 10, 76
   EMWriteScreen "N", 12, 54
 
-  EMSetCursor 10, 13
-  EMSendKey current_SSN
+  EMWritescreen left(current_SSN, 3), 10, 13
+  EMWritescreen right(left(current_SSN, 6), 2), 10, 17
+  EMwritescreen right(current_SSN, 4), 10, 20
   transmit
 
   EMWriteScreen "x", 5, 5


### PR DESCRIPTION
BLIP: Script will now clear out the last name field on PESE. In addition if the script slowed down a bit during writing the SSN into PESE it had a chance to hit transmit before SSN was fully written. This has been fixed as well.