### PR TITLE
Bug fix, PESE not getting cleared #1505

### DIFF
--- a/Script Files/DAIL/DAIL - CSES PROCESSING.vbs
+++ b/Script Files/DAIL/DAIL - CSES PROCESSING.vbs
@@ -5,10 +5,8 @@ start_time = timer
 'LOADING FUNCTIONS LIBRARY FROM GITHUB REPOSITORY===========================================================================
 IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded once
 	IF run_locally = FALSE or run_locally = "" THEN		'If the scripts are set to run locally, it skips this and uses an FSO below.
-		IF default_directory = "C:\DHS-MAXIS-Scripts\Script Files\" OR default_directory = "" THEN			'If the default_directory is C:\DHS-MAXIS-Scripts\Script Files, you're probably a scriptwriter and should use the master branch.
+		IF use_master_branch = TRUE THEN			'If the default_directory is C:\DHS-MAXIS-Scripts\Script Files, you're probably a scriptwriter and should use the master branch.
 			FuncLib_URL = "https://raw.githubusercontent.com/MN-Script-Team/BZS-FuncLib/master/MASTER%20FUNCTIONS%20LIBRARY.vbs"
-		ELSEIF beta_agency = "" or beta_agency = True then							'If you're a beta agency, you should probably use the beta branch.
-			FuncLib_URL = "https://raw.githubusercontent.com/MN-Script-Team/BZS-FuncLib/BETA/MASTER%20FUNCTIONS%20LIBRARY.vbs"
 		Else																		'Everyone else should use the release branch.
 			FuncLib_URL = "https://raw.githubusercontent.com/MN-Script-Team/BZS-FuncLib/RELEASE/MASTER%20FUNCTIONS%20LIBRARY.vbs"
 		End if
@@ -19,7 +17,7 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 			Set fso = CreateObject("Scripting.FileSystemObject")	'Creates an FSO
 			Execute req.responseText								'Executes the script code
 		ELSE														'Error message, tells user to try to reach github.com, otherwise instructs to contact Veronica with details (and stops script).
-			MsgBox 	"Something has gone wrong. The code stored on GitHub was not able to be reached." & vbCr &_ 
+			MsgBox 	"Something has gone wrong. The code stored on GitHub was not able to be reached." & vbCr &_
 					vbCr & _
 					"Before contacting Veronica Cary, please check to make sure you can load the main page at www.GitHub.com." & vbCr &_
 					vbCr & _
@@ -30,7 +28,7 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 					vbTab & vbTab & "responsible for network issues." & vbCr &_
 					vbTab & "- The URL indicated below (a screenshot should suffice)." & vbCr &_
 					vbCr & _
-					"Veronica will work with your IT department to try and solve this issue, if needed." & vbCr &_ 
+					"Veronica will work with your IT department to try and solve this issue, if needed." & vbCr &_
 					vbCr &_
 					"URL: " & FuncLib_URL
 					script_end_procedure("Script ended due to error connecting to GitHub.")
@@ -779,6 +777,7 @@ EndDialog
 
   current_SSN_with_spaces = ObjExcel.Cells(excel_row, 9).Value
   current_SSN = replace(ObjExcel.Cells(excel_row, 9).Value, " ", "")
+  EMWriteScreen "                 ", 4, 20
   EMWriteScreen "            ", 5, 20
   EMWriteScreen "            ", 6, 20
   EMWriteScreen "   ", 7, 20
@@ -791,8 +790,9 @@ EndDialog
   EMWriteScreen "N", 10, 76
   EMWriteScreen "N", 12, 54
 
-  EMSetCursor 10, 13
-  EMSendKey current_SSN
+  EMWritescreen left(current_SSN, 3), 10, 13
+  EMWritescreen right(left(current_SSN, 6), 2), 10, 17
+  EMwritescreen right(current_SSN, 4), 10, 20
   transmit
 
   EMWriteScreen "x", 5, 5


### PR DESCRIPTION
BLIP: Script will now clear out the last name field on PESE. In addition if the script slowed down a bit during writing the SSN into PESE it had a chance to hit transmit before SSN was fully written. This has been fixed as well.