### PR TITLE
Footer month update to GRH HRF

### DIFF
--- a/Script Files/NOTES/NOTES - GRH - HRF.vbs
+++ b/Script Files/NOTES/NOTES - GRH - HRF.vbs
@@ -48,12 +48,10 @@ END IF
 
 
 'DATE CALCULATIONS----------------------------------------------------------------------------------------------------
-next_month = dateadd("m", + 1, date)
-footer_month = datepart("m", next_month)
+prev_month = dateadd("m", -1, date)
+footer_month = datepart("m", prev_month)
 If len(footer_month) = 1 then footer_month = "0" & footer_month
-footer_year = datepart("yyyy", next_month)
-footer_year = "" & footer_year - 2000
-
+footer_year = right(datepart("yyyy", prev_month), 2)
 
 'DIALOGS-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 BeginDialog case_number_dialog, 0, 0, 181, 100, "Case number dialog"


### PR DESCRIPTION
Because these are for post-pay, we are looking at retro. No need to default to prospective month. Case note header has already been updated to reflect this change.

Resolves #1515


BLIP: This update defaults the footer month and year to the retro month.