### PR TITLE
Adding sanction closure info #1394

### DIFF
--- a/Script Files/NOTES/NOTES - CLOSED PROGRAMS.vbs
+++ b/Script Files/NOTES/NOTES - CLOSED PROGRAMS.vbs
@@ -48,7 +48,7 @@ END IF
 If case_noting_intake_dates = False then dialog_shrink_amt = 65
 
 'THE DIALOG----------------------------------------------------------------------------------------------------
-BeginDialog closed_dialog, 0, 0, 421, 240 - dialog_shrink_amt, "Closed progs dialog"
+BeginDialog closed_dialog, 0, 0, 421, 260 - dialog_shrink_amt, "Closed progs dialog"
   EditBox 65, 5, 55, 15, case_number
   EditBox 195, 5, 55, 15, closure_date
   CheckBox 315, 10, 35, 10, "SNAP", SNAP_check
@@ -57,29 +57,32 @@ BeginDialog closed_dialog, 0, 0, 421, 240 - dialog_shrink_amt, "Closed progs dia
   EditBox 80, 25, 340, 15, reason_for_closure
   EditBox 140, 45, 280, 15, verifs_needed
   EditBox 170, 65, 250, 15, open_progs
-  GroupBox 5, 90, 410, 45, "Elements that affect the REIN date/docs needed"
-  CheckBox 15, 100, 360, 15, "Case is at renewal (monthly, six-month, annual. Client gets entire next month after closure for REIN.)", CSR_check
+  GroupBox 5, 90, 410, 65, "Elements that affect the REIN date/docs needed"
+  CheckBox 15, 105, 360, 10, "Case is at renewal (monthy, six-month, annual. Client gets entire next month after closure for REIN.)", CSR_check
   CheckBox 15, 120, 360, 10, "Case is at HC annual renewal (can turn in HC ER instead of new HCAPP, but still counts as new application)", HC_ER_check
-  CheckBox 5, 145, 65, 10, "Updated MMIS?", updated_MMIS_check
-  CheckBox 85, 145, 95, 10, "WCOM added to notice?", WCOM_check
-  CheckBox 5, 160, 220, 10, "Check here if closure is due to client death and enter death date.", death_check
-  EditBox 230, 160, 55, 15, hc_close_for_death_date
-  EditBox 345, 140, 75, 15, worker_signature
+  CheckBox 15, 135, 215, 10, "Case is entering Sanction.     Enter number of Sanction months:", Sanction_checkbox
+  EditBox 235, 135, 25, 15, sanction_months
+  CheckBox 5, 165, 65, 10, "Updated MMIS?", updated_MMIS_check
+  CheckBox 85, 165, 95, 10, "WCOM added to notice?", WCOM_check
+  CheckBox 5, 180, 220, 10, "Check here if closure is due to client death and enter death date.", death_check
+  EditBox 230, 180, 55, 15, hc_close_for_death_date
+  EditBox 345, 160, 75, 15, worker_signature
   ButtonGroup ButtonPressed
-    OkButton 315, 160, 50, 15
-    CancelButton 370, 160, 50, 15
-    PushButton 180, 145, 50, 10, "SPEC/WCOM", SPEC_WCOM_button
+    OkButton 315, 180, 50, 15
+    CancelButton 370, 180, 50, 15
+    PushButton 180, 165, 50, 10, "SPEC/WCOM", SPEC_WCOM_button
   Text 5, 10, 50, 10, "Case number:"
   Text 135, 10, 55, 10, "Date of closure:"
   Text 265, 10, 50, 10, "Progs closed:"
   Text 5, 30, 70, 10, "Reason for closure:"
   Text 5, 50, 130, 10, "Verifs/docs/apps needed (if applicable):"
   Text 5, 70, 165, 10, "Are any programs still open? If so, list them here:"
-  Text 280, 145, 60, 10, "Worker signature: "
-  GroupBox 10, 175, 400, 60, "Please note for SNAP:"
-  Text 20, 185, 380, 25, "Per CM 0005.09.06, we no longer require completion of a CAF when the unit has been closed for less than one month AND the reason for closing has not changed, if the unit fully resolves the reason for the SNAP case closure given on the closing notice sent in MAXIS."
-  Text 20, 215, 380, 20, "As a result, SNAP cases who turn in proofs required (or otherwise become eligible for their remaining budget period) can be REINed (with proration) up until the end of the next month. If you have questions, consult a supervisor."
+  Text 280, 165, 60, 10, "Worker signature: "
+  GroupBox 10, 195, 400, 60, "Please note for SNAP:"
+  Text 20, 205, 380, 25, "Per CM 0005.09.06, we no longer require completion of a CAF when the unit has been closed for less than one month AND the reason for closing has not changed, if the unit fully resolves the reason for the SNAP case closure given on the closing notice sent in MAXIS."
+  Text 20, 235, 380, 20, "As a result, SNAP cases who turn in proofs required (or otherwise become eligible for their remaining budget period) can be REINed (with proration) up until the end of the next month. If you have questions, consult a supervisor."
 EndDialog
+
 
 'The script----------------------------------------------------------------------------------------------------
 'Connects to BlueZone
@@ -208,6 +211,12 @@ If cash_check = 1 then
   cash_followup_text = ", after which a new CAF is required."
 End if
 
+'Calculating Sanction date
+IF Sanction_checkbox = 1 Then
+	end_of_sanction = dateadd("m", Sanction_months, closure_month_first_day)
+	sanction_period = datepart("m", closure_month_first_day) & "/" & datepart("yyyy", closure_month_first_day) & "-" & datepart("m", end_of_sanction) & "/" & datepart("yyyy", end_of_sanction)
+END IF
+
 'Removing the last character of the progs_closed variable, as it is always a trailing slash
 progs_closed = left(progs_closed, len(progs_closed) - 1)
 
@@ -232,7 +241,11 @@ If HC_ER_check = 1 then call write_variable_in_case_note("* Case is at HC ER.")
 If case_noting_intake_dates = True then
 	call write_variable_in_case_note("---")
 	IF death_check <> 1 and HC_check = 1 then call write_bullet_and_variable_in_case_note("Last HC REIN date", HC_last_REIN_date & HC_followup_text)
-	If death_check <> 1 and SNAP_check = 1 then call write_bullet_and_variable_in_case_note("Last SNAP REIN date", SNAP_last_REIN_date & SNAP_followup_text)
+	If death_check <> 1 and Sanction_checkbox <> 1 and SNAP_check = 1 then
+		call write_bullet_and_variable_in_case_note("Last SNAP REIN date", SNAP_last_REIN_date & SNAP_followup_text)
+	ELSEIF Sanction_checkbox = 1 THEN
+			call write_variable_in_case_note("SNAP is entering sanction for " & sanction_months & " month(s) " & sanction_period & ". If client does not comply by closure date " & closure_date & " client will enter sanction for SNAP. Refer to worker for details on compliance.")
+	END IF
 	If death_check <> 1 and cash_check = 1 then call write_bullet_and_variable_in_case_note("Last cash REIN date", cash_last_REIN_date & cash_followup_text)
 	If open_progs <> "" and len(open_progs) > 1 and open_progs <> "no" and open_progs <> "NO" and open_progs <> "No" and open_progs <> "n/a" and open_progs <> "N/A" and open_progs <> "NA" and open_progs <> "na" then
 		call write_bullet_and_variable_in_case_note("Open programs", open_progs)


### PR DESCRIPTION
BLIP: Script will case note some details about when a case closes for entering sanction if global variables case note intake dates. 

(Fixed dialog shrink issue and typo, I'm assuming it was a goof from pulling in and out of dialog editor.)