### PR TITLE
Fixes variable name issue #1538

### DIFF
--- a/Script Files/MEMOS/MEMOS - GRH OP CL LEFT FACI.vbs
+++ b/Script Files/MEMOS/MEMOS - GRH OP CL LEFT FACI.vbs
@@ -249,8 +249,20 @@ Call check_for_MAXIS(False)
 
 
 'Actions and calculations----------------------------------------------------------------------------------------------------
+'Calculate OP total if nothing is entered.
+IF OP_total = "" THEN
+	If OP_amt_01 = "" THEN OP_amt_01 = "0"
+	If OP_amt_02 = "" THEN OP_amt_02 = "0"
+	If OP_amt_03 = "" THEN OP_amt_03 = "0"
+	If OP_amt_04 = "" THEN OP_amt_04 = "0"
+	If OP_amt_05 = "" THEN OP_amt_05 = "0"
+	If OP_amt_06 = "" THEN OP_amt_06 = "0"	
+	OP_total = (Abs(OP_amt_01) + Abs(OP_amt_02) + Abs(OP_amt_03) + Abs(OP_amt_04) + Abs(OP_amt_05) + Abs(OP_amt_06)) & ""
+END IF
+
+
 'Dollar bill symbol will be added to numeric variables 
-IF total_OP_amt <> "" THEN total_OP_amt = "$" & total_OP_amt
+IF OP_total <> "" THEN OP_total = "$" & OP_total
 IF OP_amt_01 <> "" THEN OP_amt_01 = "$" & OP_amt_01
 IF OP_amt_02 <> "" THEN OP_amt_02 = "$" & OP_amt_02
 IF OP_amt_03 <> "" THEN OP_amt_03 = "$" & OP_amt_03
@@ -303,7 +315,7 @@ IF OP_amt_03 <> "" and OP_date_03 <> "" THEN Call write_variable_in_SPEC_MEMO("*
 IF OP_amt_04 <> "" and OP_date_04 <> "" THEN Call write_variable_in_SPEC_MEMO("* " & OP_amt_04 & " for " & OP_date_04)
 IF OP_amt_05 <> "" and OP_date_05 <> "" THEN Call write_variable_in_SPEC_MEMO("* " & OP_amt_05 & " for " & OP_date_05)
 IF OP_amt_06 <> "" and OP_date_06 <> "" THEN Call write_variable_in_SPEC_MEMO("* " & OP_amt_06 & " for " & OP_date_06)
-Call write_variable_in_SPEC_MEMO("The total amount of the overpayment to be returned is: " & total_OP_amt)
+Call write_variable_in_SPEC_MEMO("The total amount of the overpayment to be returned is: " & OP_total)
 Call write_variable_in_SPEC_MEMO("Reason for the overpayment(s):" & OP_reason)
 Call write_variable_in_SPEC_MEMO("Amount client is responsible to pay for GRH during overpayment months (this amount is not to be subtracted from the total overpayment amount):" & client_amt) 
 Call write_variable_in_SPEC_MEMO("Please submit payment to:")
@@ -337,7 +349,7 @@ Call write_variable_in_CASE_NOTE ("*")
 Call write_bullet_and_variable_in_case_note("Reason for overpayment(s)", OP_reason)
 Call write_bullet_and_variable_in_case_note("Discovery date", discovery_date)
 Call write_bullet_and_variable_in_case_note("Established date", established_date)
-Call write_bullet_and_variable_in_case_note("Total overpayment amount", total_OP_amt)
+Call write_bullet_and_variable_in_case_note("Total overpayment amount", OP_total)
 Call write_bullet_and_variable_in_case_note("Amount client is responsible to pay for GRH during overpayment months",client_amt) 
 IF OP_amt_01 <> "" and OP_date_01 <> "" THEN Call write_variable_in_CASE_NOTE("* " & OP_amt_01 & " for " & OP_date_01)
 IF OP_amt_02 <> "" and OP_date_02 <> "" THEN Call write_variable_in_CASE_NOTE("* " & OP_amt_02 & " for " & OP_date_02)


### PR DESCRIPTION
BLIP: Script wasn't using the right variable to write the OP total amount. Now the script will take what is entered into the dialog for total and use it. Script will also calculate the total if the worker leaves the total field blank.