### PR TITLE
Bug fix, FP9 VS PF9 #1562

### DIFF
--- a/Script Files/NOTES/NOTES - LTC - 5181.vbs
+++ b/Script Files/NOTES/NOTES - LTC - 5181.vbs
@@ -500,7 +500,7 @@ If update_SWKR_info_checkbox = 1 THEN
 		EMWriteScreen "nn", 20, 79 'creating new panel
 		transmit
 	ELSE 
-		FP9	'putting panel into edit mode
+		PF9	'putting panel into edit mode
 	END IF 	
 	
 	'Blanks out the old info


### PR DESCRIPTION
BLIP: Script had type that cause it to be unable to PF9 on the SWKR panel. This has been fixed.