### PR TITLE
Updating approval_year write coordinates

### DIFF
--- a/Script Files/MEMOS/MEMOS - POSTPONED WREG VERIFS.vbs
+++ b/Script Files/MEMOS/MEMOS - POSTPONED WREG VERIFS.vbs
@@ -106,7 +106,7 @@ call check_for_maxis(false)
 'Gathering/formatting variables---------------------------------------------------------------------------------------------------------------------
 back_to_self
 EMWriteScreen approval_month, 20, 43
-EMWriteScreen approval_year, 20, 45
+EMWriteScreen approval_year, 20, 46
 CALL check_for_maxis(false)
 CALL navigate_to_MAXIS_screen("STAT", "PROG")   'grabbing the app date to use later.
 EMReadScreen app_date, 8, 10, 33


### PR DESCRIPTION
Resolves #1570

BLIP: This enhancement corrects an error caused by incorrect coordinates, allowing the script to get into the case in the correct benefit year.