### PR TITLE
Replacing invalid character from COPY PANELS TO WORD

### DIFF
--- a/Script Files/ACTIONS/ACTIONS - COPY PANELS TO WORD.vbs
+++ b/Script Files/ACTIONS/ACTIONS - COPY PANELS TO WORD.vbs
@@ -318,7 +318,7 @@ For each panel_to_scan in all_panels_selected_array
 					screen_on_page = 1
 					objSelection.InsertBreak(7)
 				End if
-				STATS_counter = STATS_counter + 1                      ‘adds one instance to the stats counter
+				STATS_counter = STATS_counter + 1                      'adds one instance to the stats counter
 
 	ELSE
 
@@ -346,7 +346,7 @@ For each panel_to_scan in all_panels_selected_array
 						screen_on_page = 1
 						objSelection.InsertBreak(7)
 					End if
-					STATS_counter = STATS_counter + 1                      ‘adds one instance to the stats counter
+					STATS_counter = STATS_counter + 1                      'adds one instance to the stats counter
 
 			ELSEIF panel_to_scan = "BILS" THEN
 				call navigate_to_MAXIS_screen("STAT", "BILS")
@@ -366,7 +366,7 @@ For each panel_to_scan in all_panels_selected_array
 							screen_on_page = 1
 							objSelection.InsertBreak(7)
 						End if
-						STATS_counter = STATS_counter + 1                      ‘adds one instance to the stats counter
+						STATS_counter = STATS_counter + 1                      'adds one instance to the stats counter
 					ELSEIF total_bils_panel = "1" THEN
 						call copy_screen_to_array(screentest)
 						'Adds current screen to Word doc
@@ -382,7 +382,7 @@ For each panel_to_scan in all_panels_selected_array
 							screen_on_page = 1
 							objSelection.InsertBreak(7)
 						End if
-						STATS_counter = STATS_counter + 1                      ‘adds one instance to the stats counter
+						STATS_counter = STATS_counter + 1                      'adds one instance to the stats counter
 					ELSEIF total_bils_panel <> "0" AND total_bils_panel <> "1" THEN
 						DO
 							EMReadScreen last_bils_screen, 9, 19, 66
@@ -401,7 +401,7 @@ For each panel_to_scan in all_panels_selected_array
 								objSelection.InsertBreak(7)
 							End if
 							PF20
-							STATS_counter = STATS_counter + 1                      ‘adds one instance to the stats counter
+							STATS_counter = STATS_counter + 1                      'adds one instance to the stats counter
 						LOOP until last_bils_screen = "More:   -"	
 					END IF
 
@@ -423,7 +423,7 @@ For each panel_to_scan in all_panels_selected_array
 							screen_on_page = 1
 							objSelection.InsertBreak(7)
 						End if
-						STATS_counter = STATS_counter + 1                      ‘adds one instance to the stats counter
+						STATS_counter = STATS_counter + 1                      'adds one instance to the stats counter
 					ELSEIF more_fmed_screens = "More: +" THEN
 						EMReadScreen more_fmed_screens, 7, 15, 68
 						call copy_screen_to_array(screentest)
@@ -457,7 +457,7 @@ For each panel_to_scan in all_panels_selected_array
 							screen_on_page = 1
 							objSelection.InsertBreak(7)
 						End if
-						STATS_counter = STATS_counter + 1                      ‘adds one instance to the stats counter
+						STATS_counter = STATS_counter + 1                      'adds one instance to the stats counter
 					END IF
 
 			ELSE
@@ -491,7 +491,7 @@ For each panel_to_scan in all_panels_selected_array
 					End if
 
 					current_panel = current_panel + 1
-					STATS_counter = STATS_counter + 1                      ‘adds one instance to the stats counter
+					STATS_counter = STATS_counter + 1                      'adds one instance to the stats counter
 				LOOP UNTIL (left(number_of_panels, 1) = "0") OR (current_panel = (number_of_panels + 1))
 			END IF
 		NEXT


### PR DESCRIPTION
BLIP: Removing an invalid character that is causing a critical error in the script.

Resolves #1653