### PR TITLE
BUG FIX: Added do loop to search for OTHER on new memo #1655

### DIFF
--- a/Script Files/MEMOS/MEMOS - GRH OP CL LEFT FACI.vbs
+++ b/Script Files/MEMOS/MEMOS - GRH OP CL LEFT FACI.vbs
@@ -287,7 +287,12 @@ END If
 call navigate_to_MAXIS_screen("SPEC", "MEMO")
 PF5
 'Selects "other recipient of your choosing" instead of the client to send the MEMO to
-EMWritescreen "x", 6, 10
+other_row = 6    
+DO				'loop to search for OTHER recipient
+	EMReadscreen find_other, 5, other_row, 12
+	If find_other <> "OTHER" THEN other_row = other_row + 1
+LOOP until find_other = "OTHER"
+EMWritescreen "x", other_row, 10   'writes X on row where the phrase OTHER was found. 
 transmit
 'Writes in Name of Facility and the address which MEMO is being sent
 EMWritescreen facility_name, 13, 24


### PR DESCRIPTION
BLIP: Script was incorrectly writing memos and possibly mailing to incorrect addresses if the client had any option other than OTHER on their new memo menu. Script will now search for the OTHER recipient option so it can properly write the address the worker enters.