### PR TITLE
Update NOTES - MEDICAL OPINION FORM RECEIVED.vbs

### DIFF
--- a/Script Files/NOTES/NOTES - MEDICAL OPINION FORM RECEIVED.vbs
+++ b/Script Files/NOTES/NOTES - MEDICAL OPINION FORM RECEIVED.vbs
@@ -57,11 +57,10 @@ BeginDialog MOF_recd, 0, 0, 186, 265, "Medical Opinion Form Received"
   EditBox 55, 5, 100, 15, case_number
   EditBox 55, 25, 95, 15, date_recd
   EditBox 80, 45, 90, 15, HH_Member
-  Text 5, 50, 70, 10, "HHLD Member name"
+  CheckBox 20, 65, 85, 10, "Client signed release?", client_release
   EditBox 75, 80, 100, 15, last_exam_date
   EditBox 90, 100, 85, 15, doctor_date
-  'EditBox 45, 120, 130, 15, diagnosis  'Commenting out the diagnosis field while a PI is done. See issue #1589
-  EditBox 70, 140, 105, 15, condition_will_last
+  EditBox 70, 120, 105, 15, condition_will_last
   EditBox 85, 160, 90, 15, ability_to_work
   EditBox 50, 180, 125, 15, other_notes
   EditBox 50, 200, 125, 15, action_taken
@@ -71,17 +70,16 @@ BeginDialog MOF_recd, 0, 0, 186, 265, "Medical Opinion Form Received"
     CancelButton 125, 240, 50, 15
   Text 5, 10, 50, 10, "Case Number: "
   Text 5, 30, 50, 10, "Date received: "
-  CheckBox 20, 65, 85, 10, "Client signed release?", client_release
+  Text 5, 50, 70, 10, "HHLD Member name"
   Text 5, 85, 65, 10, "Date of last exam: "
   Text 5, 105, 80, 10, "Date doctor signed form: "
-  'Text 5, 125, 40, 10, "Diagnosis" 'Commenting out the diagnosis field while a PI is done. See issue #1589
-  Text 5, 145, 65, 10, "Condition will last:"
+  Text 5, 125, 65, 10, "Condition will last:"
+  Text 5, 140, 125, 10, "Do not enter diagnosis in case notes."
   Text 5, 165, 75, 10, "Client's ability to work: "
   Text 5, 185, 40, 10, "Other notes: "
   Text 5, 205, 45, 10, "Action taken: "
   Text 5, 225, 60, 10, "Worker Signature: "
 EndDialog
-
 
 
 
@@ -118,7 +116,6 @@ Call write_bullet_and_variable_in_CASE_NOTE("Household Member", HH_Member)
 IF client_release = checked THEN CALL write_variable_in_CASE_NOTE ("* Client signed release on MOF.")
 CALL write_bullet_and_variable_in_CASE_NOTE("Date of last examination", last_exam_date)
 CALL write_bullet_and_variable_in_CASE_NOTE("Doctor signed form", doctor_date)
-'CALL write_bullet_and_variable_in_CASE_NOTE("Diagnosis", diagnosis) 'Commenting out the diagnosis field while a PI is done. See issue #1589
 CALL write_bullet_and_variable_in_CASE_NOTE("Condition will last", condition_will_last)
 CALL write_bullet_and_variable_in_CASE_NOTE("Ability to work", ability_to_work)
 CALL write_bullet_and_variable_in_CASE_NOTE("Other notes", other_notes)
@@ -126,6 +123,6 @@ CALL write_bullet_and_variable_in_CASE_NOTE("Action taken", action_taken)
 CALL write_variable_in_CASE_NOTE("---")
 CALL write_variable_in_CASE_NOTE(worker_signature)
 
-IF SNAP_ACTV = "ACTV" or SNAP_ACTV = "PEND" THEN MSGBOX "Please remember to update WREG and client's ABAWD status accordingly."  'Adds message box to remind worker to update WREG and ABAWD is SNAP is ACTV or pending
+IF SNAP_ACTV = "ACTV" or SNAP_ACTV = "PEND" THEN MSGBOX "Please remember to update WREG and client's ABAWD status accordingly."  'Adds message box to remind worker to update WREG and ABAWD if SNAP is ACTV or pending
 
 Script_end_procedure("")

--- a/Script Files/NOTES/NOTES - MEDICAL OPINION FORM RECEIVED.vbs
+++ b/Script Files/NOTES/NOTES - MEDICAL OPINION FORM RECEIVED.vbs
@@ -18,7 +18,7 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 		IF req.Status = 200 THEN									'200 means great success
 			Set fso = CreateObject("Scripting.FileSystemObject")	'Creates an FSO
 			Execute req.responseText								'Executes the script code
-		ELSE														'Error message, tells user to try to reach github.com, otherwise instructs to contact Veronica with details (and stops script).
+		ELSE															'Error message, tells user to try to reach github.com, otherwise instructs to contact Veronica with details (and stops script).
 			MsgBox 	"Something has gone wrong. The code stored on GitHub was not able to be reached." & vbCr &_
 					vbCr & _
 					"Before contacting Veronica Cary, please check to make sure you can load the main page at www.GitHub.com." & vbCr &_
@@ -74,7 +74,7 @@ BeginDialog MOF_recd, 0, 0, 186, 265, "Medical Opinion Form Received"
   Text 5, 85, 65, 10, "Date of last exam: "
   Text 5, 105, 80, 10, "Date doctor signed form: "
   Text 5, 125, 65, 10, "Condition will last:"
-  Text 5, 140, 125, 10, "Do not enter diagnosis in case notes."
+  Text 5, 140, 125, 10, "Do not enter diagnosis in case notes per PQ #16506."
   Text 5, 165, 75, 10, "Client's ability to work: "
   Text 5, 185, 40, 10, "Other notes: "
   Text 5, 205, 45, 10, "Action taken: "


### PR DESCRIPTION
Removing diagnosis language from Script due to HIPAA concerns. Text added to dialog, reminding workers not to enter diagnosis info in case note. Tab order reassigned to fix checkbox being out of place. One typo fixed in explanatory comment, because it bothered me.