### PR TITLE
fixing subsidy transtition issue #1680

### DIFF
--- a/Script Files/ACTIONS/ACTIONS - SHELTER EXPENSE VERIF RECEIVED.vbs
+++ b/Script Files/ACTIONS/ACTIONS - SHELTER EXPENSE VERIF RECEIVED.vbs
@@ -302,6 +302,7 @@ ELSE
 		EMWriteScreen "________", 18, 37
 		EMWriteScreen retro_subsidy, 18, 37
 		EMWriteScreen "SF", 18, 48
+		EMWriteScreen "Y", 6, 46	     'accounting for retro only subsidy will cause inhibiting edit 
 	ELSE
 		EMWriteScreen "________", 18, 37
 		EMWriteScreen "__", 18, 48


### PR DESCRIPTION
BLIP: Script can not handle transitions from subsidy shelter expenses.