### PR TITLE
Fixed GA bene month bug, and HCRE

### DIFF
--- a/Project Krabappel/BULK - project Krabappel.vbs
+++ b/Project Krabappel/BULK - project Krabappel.vbs
@@ -568,7 +568,7 @@ For each case_number in case_number_array
 		call create_MAXIS_friendly_date(APPL_date, 0, 10, 44)
 		call create_MAXIS_friendly_date(APPL_date, 0, 10, 55)
 	End if
-	If HC_application = True then call create_MAXIS_friendly_date(APPL_date, 0, 12, 33)		'No interview or elig begin dt for HC
+	If HC_application = True then Transmit 'MAXIS will navigate to a HCRE panel in edit mode if a PROG is completed showing HC. 
 	
 	'Enters migrant worker info
 	EMWriteScreen PROG_mig_worker, 18, 67
@@ -2170,7 +2170,7 @@ FOR EACH case_number IN case_number_array
 				'Adding 1 to the elig month
 				EMReadScreen elig_month, 2, 20, 54
 				EMReadScreen elig_year, 2, 20, 57
-				ga_bene_month = elig_month & "/" & elig_year
+				ga_bene_month = elig_month & "/01/" & elig_year
 				ga_bene_month = DateAdd("M", 1, ga_bene_month)
 				elig_month = DatePart ("M", ga_bene_month)
 				elig_year = right(DatePart("YYYY", ga_bene_month), 2)


### PR DESCRIPTION
GA bene month was running through dateadd and turning something like 12/15 into 12/15/16

HCRE function is completely useless. If HC is added to TYPE MAXIS automatically navs to HCRE and enters the app info. We have no need to train on a retro case (and approval cannot handle that either) I removed the write to HCRE function. At this time I would suggest just striking through the HCRE portion on the excel spreadsheet and telling people not to fill it out rather than deleting the rows and reprogramming all of locations. The function also contained the now deleted MAXIS_dater function. Should we leave this in funclib for the time being or just delete the write to HCRE function?