### PR TITLE
Resolves #1755

### DIFF
--- a/Script Files/ACTIONS/ACTIONS - ABAWD BANKED MONTHS FIATER.vbs
+++ b/Script Files/ACTIONS/ACTIONS - ABAWD BANKED MONTHS FIATER.vbs
@@ -709,7 +709,7 @@ For i = 0 to ubound(footer_month_array)
 		EMWritescreen ABAWD_months_array(i).SHEL_insa, 7, 29
 		EMWritescreen ABAWD_months_array(i).HEST_elect, 8, 29
 		EMWritescreen ABAWD_months_array(i).HEST_heat, 9, 29
-		EMWritescreen ABAWD_months_array(i).HEST_phone, 10, 29
+		EMWritescreen ABAWD_months_array(i).HEST_phone, 11, 29
 		EMWriteScreen ABAWD_months_array(i).SHEL_other, 12, 29
 		'this enters the proration date in the initial month'
 		IF abs(footer_month) = abs(left(proration_date, 2)) THEN


### PR DESCRIPTION
Blip: Corrects a typo that was causing the phone deduction to be entered incorrectly on the garbage deduction line in FIAT.

Pulling to release as this could occasionally cause an incorrect budget to be entered.