### PR TITLE
Keep MAGI side was reading wrong # of characters

### DIFF
--- a/Script Files/BULK/BULK - INAC SCRUBBER.vbs
+++ b/Script Files/BULK/BULK - INAC SCRUBBER.vbs
@@ -173,7 +173,7 @@ IF MAGI_cases_closed_four_month_TIKL_no_XFER = TRUE THEN
 	transmit
 	
 	'Checks to make sure the selected worker number is the default. If not it will navigate to that person.
-	EMReadScreen worker_number_check, 3, 21, 16
+	EMReadScreen worker_number_check, 7, 21, 16
 	If ucase(worker_number_check) <> ucase(worker_number) then
 		EMWriteScreen worker_number, 21, 16
 		transmit


### PR DESCRIPTION
BLIP: script was reading wrong number of characters causing problems on case loads with more than 1 page of inactive cases ran by that user.

Resolves #1774 