### PR TITLE
Resolves #1794: TYMA variable now included in GlobVar

### DIFF
--- a/Script Files/SETTINGS - GLOBAL VARIABLES.vbs
+++ b/Script Files/SETTINGS - GLOBAL VARIABLES.vbs
@@ -51,6 +51,8 @@ CLS_x1_number = ""
 'This is a TRUE/FALSE that will tell the INAC scrubber to hold onto MAGI cases that closed for no/incomplete renewals for 4 months or not.
 MAGI_cases_closed_four_month_TIKL_no_XFER = FALSE
 
+'This is a setting for the TYMA TIKLer script. When set to "true", TYMA TIKLer will TIKL all TYMA months simultaneously, as opposed to only the first month. Defaullt is "false".
+TYMA_TIKL_all_at_once = false
 
 'NAVIGATION SCRIPT CONFIGURATION================
 


### PR DESCRIPTION
Blip: TYMA_TIKL_all_at_once has been added to the Global Variables file.
The default behavior both in the script and the Global Variables file is
to set this to false. Agencies installing or reinstalling scripts will
be able to modify this variable in the installer.