### PR TITLE
Resolves #1871 and #1872 NOTICES SNAP E&T LETTER bugs

### DIFF
--- a/Script Files/NOTICES/NOTICES - SNAP E AND T LETTER.vbs
+++ b/Script Files/NOTICES/NOTICES - SNAP E AND T LETTER.vbs
@@ -124,7 +124,7 @@ IF worker_county_code = "x165" THEN county_FSET_offices = array("Central MN Jobs
 'IF worker_county_code = "x166" THEN county_FSET_offices = array("Select one...",
 IF worker_county_code = "x167" THEN county_FSET_offices = array("Southwest MN Private Industry Council Inc. Luverne")
 IF worker_county_code = "x168" THEN county_FSET_offices = array("Roseau County Social Services")
-IF worker_county_code = "x169" THEN county_FSET_offices = array("Select one...", "MN Workforce Center: Duluth", "Minnesota WorkForce Center: Virginia", "Minnesota Workforce Center: Hibbing")
+IF worker_county_code = "x169" THEN county_FSET_offices = array("Select one...", "Minnesota Workforce Center Duluth", "Minnesota WorkForce Center: Virginia", "Minnesota Workforce Center: Hibbing")
 'IF worker_county_code = "x170" THEN county_FSET_offices = array("Select one...",
 IF worker_county_code = "x171" THEN county_FSET_offices = array("Central MN Jobs and Training Services Monticello")
 'IF worker_county_code = "x172" THEN county_FSET_offices = array("Select one...",
@@ -855,7 +855,7 @@ IF interview_location  = "Roseau County Social Services" THEN
 END IF
 
 'CO #69 SAINT LOUIS COUNTY address
-IF interview_location  = "Minnesota WorkForce Center: Duluth" THEN
+IF interview_location  = "Minnesota WorkForce Center Duluth" THEN
     SNAPET_name = "Minnesota WorkForce Center: Duluth"
     SNAPET_address_01 = "402 W. 1st Street Room 119"
     SNAPET_city = "Duluth"
@@ -1063,6 +1063,7 @@ EMReadScreen LETR_check, 4, 2, 49
 If LETR_check = "LETR" then script_end_procedure("You are not able to go into update mode. Did you enter in inquiry by mistake? Please try again in production.")
 
 'Writes the info into the LETR.
+IF len(appointment_time_prefix_editbox) = 1 THEN appointment_time_prefix_editbox = "0" & appointment_time_prefix_editbox 'This prevents the letter from being cancelled due to single digit hour
 EMWriteScreen first_name & " " & last_name, 4, 28
 call create_MAXIS_friendly_date_three_spaces_between(appointment_date, 0, 6, 28)
 EMWriteScreen appointment_time_prefix_editbox, 7, 28


### PR DESCRIPTION
Blip: Corrects a bug that prevented the script from sending a letter when a single digit hour was entered for the appointment time.  Corrects a typo that prevented the script from working for the Duluth office.