### PR TITLE
Resolved #1821- Check for expiration

### DIFF
--- a/Script Files/DAIL/DAIL - NEW HIRE NDNH.vbs
+++ b/Script Files/DAIL/DAIL - NEW HIRE NDNH.vbs
@@ -229,6 +229,8 @@ If create_JOBS_checkbox = checked then
 		transmit
 	End if
 	transmit						'Transmits to submit the panel
+	EMReadScreen expired_check, 6, 24, 17 'Checks to see if the jobs panel will carry over by looking for the "This information will expire" at the bottom of the page
+		If expired_check = "EXPIRE" THEN Msgbox "Check next footer month to make sure the JOBS panel carried over"
 End if
 
 'Navigates back to DAIL

--- a/Script Files/DAIL/DAIL - NEW HIRE.vbs
+++ b/Script Files/DAIL/DAIL - NEW HIRE.vbs
@@ -219,7 +219,10 @@ If create_JOBS_checkbox = checked then
 		transmit
 	End if
 	transmit						'Transmits to submit the panel
+	EMReadScreen expired_check, 6, 24, 17 'Checks to see if the jobs panel will carry over by looking for the "This information will expire" at the bottom of the page
+		If expired_check = "EXPIRE" THEN Msgbox "Check next footer month to make sure the JOBS panel carried over"
 End if
+
 
 'Navigates back to DAIL
 Do
@@ -228,6 +231,7 @@ Do
 	PF3
 Loop until DAIL_check = "DAIL"
 
+msgbox "Do you want to case note?"
 'Navigates to case note
 EMSendKey "n"
 transmit

--- a/Script Files/DAIL/DAIL - NEW HIRE.vbs
+++ b/Script Files/DAIL/DAIL - NEW HIRE.vbs
@@ -231,7 +231,6 @@ Do
 	PF3
 Loop until DAIL_check = "DAIL"
 
-msgbox "Do you want to case note?"
 'Navigates to case note
 EMSendKey "n"
 transmit


### PR DESCRIPTION
Added feature to New Hire Dail Scrubber. When the script enters a Jobs panel, it checks for the "This Information will expire ..." which indicates that the JOBS panel will not carry forward to the next footer month. When this happens the script will now give you a Msgbox to alert the worker to check the next footer month.