### PR TITLE
Resolved #1965: added slash to run_locally script_repository variable

### DIFF
--- a/Script Files/SETTINGS - GLOBAL VARIABLES.vbs
+++ b/Script Files/SETTINGS - GLOBAL VARIABLES.vbs
@@ -122,4 +122,4 @@ ELSE							'Everyone else (who isn't a scriptwriter) typically uses the release 
 END IF
 
 'If run locally is set to "True", the scripts will totally bypass GitHub and run locally.
-IF run_locally = TRUE THEN script_repository = "C:\DHS-MAXIS-Scripts\Script Files"
+IF run_locally = TRUE THEN script_repository = "C:\DHS-MAXIS-Scripts\Script Files\"


### PR DESCRIPTION
Blip: a slash was added to the `script_repository` variable if
`run_locally` is set to true. This makes the `script_repository` logic
match other scripts when testing DAIL Scrubber enhancements.