### PR TITLE
Resolves #2009 - Adding a check_for_MAXIS in Paystubs Received

### DIFF
--- a/Script Files/ACTIONS/ACTIONS - PAYSTUBS RECEIVED.vbs
+++ b/Script Files/ACTIONS/ACTIONS - PAYSTUBS RECEIVED.vbs
@@ -305,6 +305,10 @@ DO
 	END IF
 LOOP UNTIL err_msg = ""
 
+'Checking for MAXIS. It could take a while to enter all the pay information
+'Making it false because it would be turbo irritating to shut down the script after entering all that information
+CALL check_for_MAXIS(false)
+
 'Turns on edit mode
 PF9
 


### PR DESCRIPTION
BLIP: Adding a time-out check to Paystubs Received to help reduce the number of times workers suspend themselves after entering complex pay information into the script.