### PR TITLE
RESOLVES #2098 correcting verbiage/adding state_a_blank_case_note

### DIFF
--- a/Script Files/DAIL/DAIL - SEND NOMI.vbs
+++ b/Script Files/DAIL/DAIL - SEND NOMI.vbs
@@ -107,7 +107,7 @@ If interview_confirm = TRUE then
 	script_end_procedure("Success! A NOMI is not required if the recertification interview is complete." & vbNewLine & "Please review the case for completion if necessary.")
 ELSE
 	'Msgbox asking the user to confirm if the client has sent a CAF or if no contact has been made by the client
-	recert_forms_confirm = MsgBox("A NOMI is needed when a SNAP recipient has not made contact with the agency about their recertification, AND the CAF has not been received." & vbNewLine & vbNewLine & "Press Yes to send the NOMI." & _
+	recert_forms_confirm = MsgBox("A NOMI is NOT needed when a SNAP recipient has not made contact with the agency about their recertification, AND the CAF has not been received." & vbNewLine & "See TE.02.05.15" & vbNewLine & vbNewLine & "Press Yes to send the NOMI." & _
 	vbNewLine & "Press No if client contact has not been made with the agency." & vbNewLine & "Press Cancel to end the script.", vbYesNoCancel, "Client contact confirmation")
 		If recert_forms_confirm = vbCancel then stopscript
 		If recert_forms_confirm = vbYes then result_of_msgbox = TRUE
@@ -117,7 +117,7 @@ END IF
 If result_of_msgbox = FALSE then		'if false a case note will be made, but a NOMI will not be sent as this is not necessary. 
 	dialog worker_signature_dialog
 	If ButtonPressed_worker_signature_dialog = 0 then stopscript
-	PF9	'goes directly into edit mode
+	Call start_a_blank_case_note 'Navigates to a blank case note & writes the case note
 	Call write_variable_in_CASE_NOTE ("**Client missed SNAP recertification interview**")
 	Call write_variable_in_CASE_NOTE("* Interview appointment was scheduled for: " & interview_date_time)
 	Call write_variable_in_CASE_NOTE ("* A SNAP NOMI for recertification SPEC/MEMO has not been sent.")


### PR DESCRIPTION
BLIP: verbiage on question about when to send NOMI was reworked to read better to end users. Corrected issue that caused infinite loop when trying to run in inquiry.