### PR TITLE
resolves #2149 fixing link name

### DIFF
--- a/Script Files/NOTICES/NOTICES - MAIN MENU.vbs
+++ b/Script Files/NOTICES/NOTICES - MAIN MENU.vbs
@@ -211,7 +211,7 @@ script_num = script_num + 1								'Increment by one
 ReDim Preserve script_array_NOTICES_list(script_num)		'Resets the array to add one more element to it
 Set script_array_NOTICES_list(script_num) = new script		'Set this array element to be a new script. Script details below...
 script_array_NOTICES_list(script_num).script_name 			= "  Banked Month WCOMS "
-script_array_NOTICES_list(script_num).file_name			= "NOTICES - BANKED MONTH WCOMS.vbs"
+script_array_NOTICES_list(script_num).file_name			= "NOTICES - BANKED MONTHS WCOMS.vbs"
 script_array_NOTICES_list(script_num).description 			= "Adds various WCOMS to a notice for regarding banked month approvals/closure."
 
 script_num = script_num + 1								'Increment by one


### PR DESCRIPTION
BLIP: fix to link name, script couldn't find banked month WCOM script due to typo.