### PR TITLE
Resolved #2145: county_name removed from Global Variables

### DIFF
--- a/Script Files/SETTINGS - GLOBAL VARIABLES.vbs
+++ b/Script Files/SETTINGS - GLOBAL VARIABLES.vbs
@@ -18,9 +18,6 @@ run_locally = true
 'This is used by almost every script which calls a specific agency worker number (like the REPT/ACTV nav and list gen scripts).
 worker_county_code = "MULTICOUNTY"
 
-'This is used for MEMO scripts, such as appointment letter
-county_name = "Anoka County"
-
 'This merely exists to help the installer determine which dropdown box to default. It is not used by any scripts.
 code_from_installer = "SCRIPTWRITER"
 


### PR DESCRIPTION
BLIP: The `county_name` variable was removed from Global Variables, as the new function `get_county_code` determines this programmatically.