### PR TITLE
Resolves #2008: BrowseForFile is now history

### DIFF
--- a/Script Files/BULK/BULK - CASE NOTE FROM LIST.vbs
+++ b/Script Files/BULK/BULK - CASE NOTE FROM LIST.vbs
@@ -164,17 +164,6 @@ FUNCTION convert_excel_letter_to_excel_number(excel_col)
 	END IF
 END FUNCTION
 
-'-------THIS FUNCTION ALLOWS THE USER TO PICK AN EXCEL FILE---------
-Function BrowseForFile()
-    Dim shell : Set shell = CreateObject("Shell.Application")
-    Dim file : Set file = shell.BrowseForFolder(0, "Choose a file:", &H4000, "Computer")
-	IF file is Nothing THEN 
-		script_end_procedure("The script will end.")
-	ELSE
-		BrowseForFile = file.self.Path
-	END IF
-End Function
-
 'The script===========================
 EMConnect ""
 
@@ -245,10 +234,10 @@ DIALOG main_menu
 		'Opening the Excel file
 		
 		DO
-			'file_location = InputBox("Please enter the file location.")
+			call file_selection_system_dialog(excel_file_path, ".xlsx")
 			
 			Set objExcel = CreateObject("Excel.Application")
-			Set objWorkbook = objExcel.Workbooks.Open(BrowseForFile)
+			Set objWorkbook = objExcel.Workbooks.Open(excel_file_path)
 			objExcel.Visible = True
 			objExcel.DisplayAlerts = True
 			

--- a/Script Files/BULK/BULK - MEMO FROM LIST.vbs
+++ b/Script Files/BULK/BULK - MEMO FROM LIST.vbs
@@ -151,17 +151,6 @@ FUNCTION convert_excel_letter_to_excel_number(excel_col)
 	END IF
 END FUNCTION
 
-'-------THIS FUNCTION ALLOWS THE USER TO PICK AN EXCEL FILE---------
-Function BrowseForFile()
-    Dim shell : Set shell = CreateObject("Shell.Application")
-    Dim file : Set file = shell.BrowseForFolder(0, "Choose a file:", &H4000, "Computer")
-	IF file is Nothing THEN 
-		script_end_procedure("The script will end.")
-	ELSE
-		BrowseForFile = file.self.Path
-	END IF
-End Function
-
 'The script===========================
 EMConnect ""
 
@@ -232,10 +221,10 @@ DIALOG main_menu
 		'Opening the Excel file
 		
 		DO
-			'file_location = InputBox("Please enter the file location.")
+			call file_selection_system_dialog(excel_file_path, ".xlsx")	'Selects an excel file, adds it to excel_file_path
 			
 			Set objExcel = CreateObject("Excel.Application")
-			Set objWorkbook = objExcel.Workbooks.Open(BrowseForFile)
+			Set objWorkbook = objExcel.Workbooks.Open(excel_file_path)
 			objExcel.Visible = True
 			objExcel.DisplayAlerts = True
 			

--- a/Script Files/BULK/BULK - TIKL FROM LIST.vbs
+++ b/Script Files/BULK/BULK - TIKL FROM LIST.vbs
@@ -158,17 +158,6 @@ FUNCTION convert_excel_letter_to_excel_number(excel_col)
 	END IF
 END FUNCTION
 
-'-------THIS FUNCTION ALLOWS THE USER TO PICK AN EXCEL FILE---------
-Function BrowseForFile()
-    Dim shell : Set shell = CreateObject("Shell.Application")
-    Dim file : Set file = shell.BrowseForFolder(0, "Choose a file:", &H4000, "Computer")
-	IF file is Nothing THEN 
-		script_end_procedure("The script will end.")
-	ELSE
-		BrowseForFile = file.self.Path
-	END IF
-End Function
-
 'The script===========================
 EMConnect ""
 
@@ -240,10 +229,10 @@ DIALOG main_menu
 		'Opening the Excel file
 		
 		DO
-			'file_location = InputBox("Please enter the file location.")
+			call file_selection_system_dialog(excel_file_path, ".xlsx")	'Selects an excel file, adds it to excel_file_path
 			
 			Set objExcel = CreateObject("Excel.Application")
-			Set objWorkbook = objExcel.Workbooks.Open(BrowseForFile)
+			Set objWorkbook = objExcel.Workbooks.Open(excel_file_path)
 			objExcel.Visible = True
 			objExcel.DisplayAlerts = True
 			

--- a/Script Files/BULK/BULK - UPDATE EOMC LIST.vbs
+++ b/Script Files/BULK/BULK - UPDATE EOMC LIST.vbs
@@ -43,16 +43,7 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 	END IF
 END IF
 'END FUNCTIONS LIBRARY BLOCK================================================================================================
-'This function pulls up a file browser'
-Function BrowseForFile()
-	Dim shell : Set shell = CreateObject("Shell.Application")
-	Dim file : Set file = shell.BrowseForFolder(0, "Choose a file:", &H4000, "Computer")
-	IF file is Nothing THEN
-		script_end_procedure("The script will end.")
-	ELSE
-		BrowseForFile = file.self.Path
-	END IF
-End Function
+
 'this function converts excel column letters to numeric values'
 FUNCTION convert_excel_letter_to_excel_number(excel_col)
 	IF isnumeric(excel_col) = FALSE THEN
@@ -89,8 +80,11 @@ EndDialog
 dialog dialog1
 DO 'THIS loop makes sure this is a valid file created by EOMC'
 	DO 'This loop opens the file browser and asks user to confirm'
+	
+		call file_selection_system_dialog(excel_file_path, ".xlsx")	'Selects an excel file, adds it to excel_file_path
+	
 		Set objExcel = CreateObject("Excel.Application")
-		Set objWorkbook = objExcel.Workbooks.Open(BrowseForFile)
+		Set objWorkbook = objExcel.Workbooks.Open(excel_file_path)
 		objExcel.Visible = True
 		objExcel.DisplayAlerts = True
 


### PR DESCRIPTION
Replaced with the following logic: `call file_selection_system_dialog(excel_file_path, ".xlsx")	'Selects an excel file, adds it to excel_file_path`

Blip: The script was updated to replace the Excel file browser with the Windows standard file browser, which contains logic for looking at recent places, favorite locations, and multiple shared drives.

Scripts updated:
* CASE NOTE FROM LIST
* MEMO FROM LIST
* TIKL FROM LIST
* UPDATE EOMC LIST