### PR TITLE
RESOLVES #2251 Accounting for change to JOBS panel

### DIFF
--- a/Script Files/ACTIONS/ACTIONS - MA-EPD EI FIAT.vbs
+++ b/Script Files/ACTIONS/ACTIONS - MA-EPD EI FIAT.vbs
@@ -96,7 +96,12 @@ If jobs_current = "1" then
   If pay_freq_01 = "3" then frequency_job_01 = "3: every 2 weeks"
   If pay_freq_01 = "4" then frequency_job_01 = "4. every week"
   If pay_freq_01 = "5" then frequency_job_01 = "5. other (use monthly avg)"
-  EMWriteScreen "x", 19, 54
+  EMReadScreen HC_income_est_check, 3, 19, 63 'reading to find the HC income estimator is moving 6/1/16, to account for if it only affects future months we are reading to find the HC inc EST
+  IF HC_income_est_check = "Est" Then 'this is the old position
+	EMWriteScreen "x", 19, 54
+  ELSE								'this is the new position
+	EMWriteScreen "x", 19, 48
+  END IF
   transmit
   EMReadScreen income_job_01, 8, 11, 63
   income_job_01 = trim(replace(income_job_01, "_", ""))
@@ -112,7 +117,12 @@ If jobs_current = "2" then
   If pay_freq_02 = "3" then frequency_job_02 = "3: every 2 weeks"
   If pay_freq_02 = "4" then frequency_job_02 = "4. every week"
   If pay_freq_02 = "5" then frequency_job_02 = "5. other (use monthly avg)"
-  EMWriteScreen "x", 19, 54
+  EMReadScreen HC_income_est_check, 3, 19, 63 'reading to find the HC income estimator is moving 6/1/16, to account for if it only affects future months we are reading to find the HC inc EST
+  IF HC_income_est_check = "Est" Then 'this is the old position
+	EMWriteScreen "x", 19, 54
+  ELSE								'this is the new position
+	EMWriteScreen "x", 19, 48
+  END IF
   transmit
   EMReadScreen income_job_02, 8, 11, 63
   income_job_02 = trim(replace(income_job_02, "_", ""))
@@ -128,7 +138,12 @@ If jobs_current = "3" then
   If pay_freq_03 = "3" then frequency_job_03 = "3: every 2 weeks"
   If pay_freq_03 = "4" then frequency_job_03 = "4. every week"
   If pay_freq_03 = "5" then frequency_job_03 = "5. other (use monthly avg)"
-  EMWriteScreen "x", 19, 54
+  EMReadScreen HC_income_est_check, 3, 19, 63 'reading to find the HC income estimator is moving 6/1/16, to account for if it only affects future months we are reading to find the HC inc EST
+  IF HC_income_est_check = "Est" Then 'this is the old position
+	EMWriteScreen "x", 19, 54
+  ELSE								'this is the new position
+	EMWriteScreen "x", 19, 48
+  END IF
   transmit
   EMReadScreen income_job_03, 8, 11, 63
   income_job_03 = trim(replace(income_job_03, "_", ""))

--- a/Script Files/ACTIONS/ACTIONS - PAYSTUBS RECEIVED.vbs
+++ b/Script Files/ACTIONS/ACTIONS - PAYSTUBS RECEIVED.vbs
@@ -38,6 +38,9 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 END IF
 'END FUNCTIONS LIBRARY BLOCK================================================================================================
 
+case_number = "226545"
+MAXIS_case_number = "226545"
+
 'CUSTOM FUNCTIONS
 Function prospective_averager(pay_date, gross_amt, hours, paystubs_received, total_prospective_pay, total_prospective_hours) 'Creates variables for total_prospective_pay and total_prospective_hours
   If isdate(pay_date) = True then
@@ -525,7 +528,12 @@ Do
 
 	'If the footer month is the current month + 1, the script needs to update the HC popup for HC cases.
 	If update_HC_popup_check = 1 and datediff("m", date, MAXIS_footer_month & "/01/" & MAXIS_footer_year) = 1 then
-		EMWriteScreen "x", 19, 54
+		EMReadScreen HC_income_est_check, 3, 19, 63 'reading to find the HC income estimator is moving 6/1/16, to account for if it only affects future months we are reading to find the HC inc EST
+		IF HC_income_est_check = "Est" Then 'this is the old position
+			EMWriteScreen "x", 19, 54
+		ELSE								'this is the new position
+			EMWriteScreen "x", 19, 48
+		END IF
 		transmit
 		EMWriteScreen "________", 11, 63
 		EMWriteScreen average_pay_per_paystub, 11, 63

--- a/Script Files/ACTIONS/ACTIONS - PAYSTUBS RECEIVED.vbs
+++ b/Script Files/ACTIONS/ACTIONS - PAYSTUBS RECEIVED.vbs
@@ -38,9 +38,6 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 END IF
 'END FUNCTIONS LIBRARY BLOCK================================================================================================
 
-case_number = "226545"
-MAXIS_case_number = "226545"
-
 'CUSTOM FUNCTIONS
 Function prospective_averager(pay_date, gross_amt, hours, paystubs_received, total_prospective_pay, total_prospective_hours) 'Creates variables for total_prospective_pay and total_prospective_hours
   If isdate(pay_date) = True then


### PR DESCRIPTION
BLIP: Script can now handle change in position of HC income estimator. Script can do this as well as current location of estimator to make the transition to the new panel more smooth if both version are available at the same time.