### PR TITLE
Resolved #2258 (partial): Fixed content check/REVS

### DIFF
--- a/Script Files/BULK/BULK - REPT-REVS LIST.vbs
+++ b/Script Files/BULK/BULK - REPT-REVS LIST.vbs
@@ -213,8 +213,8 @@ For each worker in worker_array
 	review_date = MAXIS_footer_month & "/01/" & MAXIS_footer_year
 
 	'Skips workers with no info
-	EMReadScreen has_content_check, 1, 7, 8
-	If has_content_check <> " " then
+	EMReadScreen has_content_check, 8, 7, 6
+	If has_content_check <> "        " then
 
 		'Grabbing each case number on screen
 		Do


### PR DESCRIPTION
REPT REVS List has_content_check has been updated to look for an entire case number rather than one digit, eliminating missed cases on the bulk list.