### PR TITLE
RESOLVES #2392 Adding pause for dev mode

### DIFF
--- a/Script Files/BULK/BULK - INAC SCRUBBER.vbs
+++ b/Script Files/BULK/BULK - INAC SCRUBBER.vbs
@@ -731,7 +731,9 @@ For x = 0 to total_cases
 			PF9
 			EMWriteScreen CLS_x1_number, 18, 61		
 			transmit
+			
 		Else
+			Msgbox INAC_scrubber_primary_array(x, 0) & " transfered to " & CLS_x1_number    'leading a messagebox to show developer what case is being transferred and to where. This pause insures loop is operating correctly.
 			objExcel.Cells(x+2, 10).Value = "TRANSFERRED"
 		End if
 	End if


### PR DESCRIPTION
BLIP: when running the script in developer mode the script will now pause and display the case number, and the CLS number it is being transferred to.