### PR TITLE
Resolved #2415, Resolved #2373: NOTES - Approved Programs 

### DIFF
--- a/Script Files/NOTES/NOTES - APPROVED PROGRAMS.vbs
+++ b/Script Files/NOTES/NOTES - APPROVED PROGRAMS.vbs
@@ -76,8 +76,6 @@ BeginDialog benefits_approved, 0, 0, 271, 235, "Benefits Approved"
   Text 5, 25, 50, 10, "Case Number:"
 EndDialog
 
-
-
 'THE SCRIPT----------------------------------------------------------------------------------------------------
 'connecting to MAXIS
 EMConnect ""
@@ -134,9 +132,6 @@ Do
 	call check_for_password(are_we_passworded_out)  'Adding functionality for MAXIS v.6 Passworded Out issue'
 Loop until are_we_passworded_out = false
 
-'checking for an active MAXIS session
-Call check_for_MAXIS(FALSE)  
-
 Call date_array_generator (start_mo, start_yr, date_array)
 
 Dim bene_amount_array ()	'Array to store all the different elig amounts
@@ -192,7 +187,7 @@ IF SNAP_banked_mo_check = checked THEN
 		Emreadscreen edit_check, 7, 24, 2 
 	LOOP until edit_check = "ENTER A"			'the script will continue to transmit through memb until it reaches the last page and finds the ENTER A edit on the bottom row. 
 
-	wreg_check = 0 		'c
+	wreg_check = 0 		'zero-ing out the value of wreg_check variable
 
 	DO 		'Gets information from WREG for each client 
 		navigate_to_MAXIS_screen "STAT", "WREG"
@@ -329,42 +324,48 @@ IF SNAP_banked_mo_check = checked THEN
 					set abawdrs = nothing
 				NEXT
 				objConnection.close
-			Else
-
-				'For counties with no Access DB set up - this is create an excel sheet with the months listed - counties will need to determine their tracking process at this time
-				'Opening the Excel file
-				Set objExcel = CreateObject("Excel.Application")
-				objExcel.Visible = True
-				Set objWorkbook = objExcel.Workbooks.Add() 
-				objExcel.DisplayAlerts = True
-				
-				'Setting the first 4 col as worker, case number, name, and APPL date
-				ObjExcel.Cells(1, 1).Value = "CASE NUMBER"
-				objExcel.Cells(1, 1).Font.Bold = TRUE
-				ObjExcel.Cells(excel_row, 1).Value = MAXIS_case_number
-				ObjExcel.Cells(1, 2).Value = "CLT REF #"
-				objExcel.Cells(1, 2).Font.Bold = TRUE
-				ObjExcel.Cells(excel_row, 2).Value = BM_Clients_Array(0, clt_banked_mo_apprvd)
-				ObjExcel.Cells(1, 3).Value = "CLT NAME"
-				objExcel.Cells(1, 3).Font.Bold = TRUE
-				ObjExcel.Cells(excel_row, 3).Value = BM_Clients_Array(1, clt_banked_mo_apprvd)
-				ObjExcel.Cells(1, 4).Value = "1st Banked Month"
-				objExcel.Cells(1, 4).Font.Bold = TRUE
-				ObjExcel.Cells(1, 5).Value = "2nd Banked Month"
-				objExcel.Cells(1, 5).Font.Bold = TRUE
-				ObjExcel.Cells(1, 6).Value = "3rd Banked Month"
-				objExcel.Cells(1, 6).Font.Bold = TRUE
-				
-				month_col = 4 
-				For v = 0 to UBound(Used_ABAWD_Months_Array)
-					ObjExcel.Cells(excel_row, month_col).Value = Used_ABAWD_Months_Array(v)
-					month_col = month_col + 1 
-				Next 
-				
-				'Autofitting columns
-				For col_to_autofit = 1 to 6
-					ObjExcel.columns(col_to_autofit).AutoFit()
-				Next
+			END IF
+			
+			IF banked_months_db_tracking = False Then	
+				If worker_county_code <> "x127" then
+					If worker_county_code <> "x162" then 
+						msgbox "The Excel spreadsheet function will be depreciated effective August 22, 2016. If are an agency who uses this functionality exclusively to track banked months, please submit a comment on GitHub (Issue #2373). Thank you."
+					
+						'Opening the Excel file
+						Set objExcel = CreateObject("Excel.Application")
+						objExcel.Visible = True
+						Set objWorkbook = objExcel.Workbooks.Add() 
+						objExcel.DisplayAlerts = True
+						
+						'Setting the first 4 col as worker, case number, name, and APPL date
+						ObjExcel.Cells(1, 1).Value = "CASE NUMBER"
+						objExcel.Cells(1, 1).Font.Bold = TRUE
+						ObjExcel.Cells(excel_row, 1).Value = MAXIS_case_number
+						ObjExcel.Cells(1, 2).Value = "CLT REF #"
+						objExcel.Cells(1, 2).Font.Bold = TRUE
+						ObjExcel.Cells(excel_row, 2).Value = BM_Clients_Array(0, clt_banked_mo_apprvd)
+						ObjExcel.Cells(1, 3).Value = "CLT NAME"
+						objExcel.Cells(1, 3).Font.Bold = TRUE
+						ObjExcel.Cells(excel_row, 3).Value = BM_Clients_Array(1, clt_banked_mo_apprvd)
+						ObjExcel.Cells(1, 4).Value = "1st Banked Month"
+						objExcel.Cells(1, 4).Font.Bold = TRUE
+						ObjExcel.Cells(1, 5).Value = "2nd Banked Month"
+						objExcel.Cells(1, 5).Font.Bold = TRUE
+						ObjExcel.Cells(1, 6).Value = "3rd Banked Month"
+						objExcel.Cells(1, 6).Font.Bold = TRUE
+						
+						month_col = 4 
+						For v = 0 to UBound(Used_ABAWD_Months_Array)
+							ObjExcel.Cells(excel_row, month_col).Value = Used_ABAWD_Months_Array(v)
+							month_col = month_col + 1 
+						Next 
+							
+							'Autofitting columns
+						For col_to_autofit = 1 to 6
+							ObjExcel.columns(col_to_autofit).AutoFit()
+						Next
+					END IF
+				End if
 			End If
 			
 			'Writing a TIKL to close SNAP once Banked Months are done for this person
@@ -724,18 +725,12 @@ For all_elig_results = 0 to UBound (bene_amount_array,2)
 	END IF 
 Next 
 
-
-
 'Case notes----------------------------------------------------------------------------------------------------
 IF clt_banked_mo_apprvd <> 0 THEN 	'BANKED MONTH Case Note - each client gets a seperate case note 
 	For clt_banked_mo_apprvd = 0 to UBound (BM_Clients_Array,2)
 		Call start_a_blank_CASE_NOTE
 		Call write_variable_in_CASE_NOTE ("!~!~! Memb " & BM_Clients_Array(0,clt_banked_mo_apprvd) & "used BANKED MONTHS in " & BM_Clients_Array (2, clt_banked_mo_apprvd) & " !~!~!")	'Months used moved to header
-		IF worker_county_code = "x169" THEN 
-			Call write_variable_in_CASE_NOTE ("BANKED MONTH Information added to Database for reporting")
-		Else 
-			Call write_variable_in_CASE_NOTE ("Excel Sheet created for manual tracking of BANKED MONTHS")
-		End IF 
+		IF worker_county_code = "x169" THEN Call write_variable_in_CASE_NOTE ("BANKED MONTH Information added to Database for reporting")
 		IF tikl_set = TRUE Then Call write_variable_in_CASE_NOTE ("TIKL Created to close SNAP for " & cls_date)
 		Call write_variable_in_CASE_NOTE ("---")
 		Call write_variable_in_CASE_NOTE (worker_signature)

--- a/Script Files/NOTES/NOTES - APPROVED PROGRAMS.vbs
+++ b/Script Files/NOTES/NOTES - APPROVED PROGRAMS.vbs
@@ -331,6 +331,7 @@ IF SNAP_banked_mo_check = checked THEN
 					If worker_county_code <> "x162" then 
 						msgbox "The Excel spreadsheet function will be depreciated effective August 22, 2016. If are an agency who uses this functionality exclusively to track banked months, please submit a comment on GitHub (Issue #2373). Thank you."
 					
+						'For counties (who are not Hennepin and Ramsey) with no Access DB set up - this is create an excel sheet with the months listed - counties will need to determine their tracking process at this time
 						'Opening the Excel file
 						Set objExcel = CreateObject("Excel.Application")
 						objExcel.Visible = True
@@ -812,7 +813,4 @@ IF SNAP_banked_mo_check = checked THEN Call write_variable_in_CASE_NOTE ("BANKED
 call write_variable_in_CASE_NOTE("---")
 call write_variable_in_CASE_NOTE(worker_signature)
 
-'Navigates to WCOM so the user can check the notice.
-call navigate_to_MAXIS_screen("SPEC", "WCOM")
-
-script_end_procedure("Success! Please remember to check the generated notice to make sure it reads correctly. If not please add WCOMs to make notice read correctly. The script has navigated to SPEC/WCOM for your convenience.")
+script_end_procedure("Success! Please remember to check the generated notice to make sure it is correct. If not, please add WCOMs to make notice read correctly.")


### PR DESCRIPTION
BLIP (for issue 2415): Removed the navigation to SPEC/WCOM after the case note has been made. The script will revert to ending in CASE/NOTE in edit mode. Also updated the script closing text to reflect that the script is not in SPEC/WCOM.

BLIP (for issue 2373): For Hennepin and Ramsey County users, removed Excel list created when the case is identified as banked months. Hennepin and Ramsey County use the process detailed in the BULK - BANKED MONTHS REPORT (https://www.dhssir.cty.dhs.state.mn.us/MAXIS/blzn/Script%20Instructions%20Wiki/Banked%20Months%20Report.aspx) 
For all other users that do use gather statistics using a database (St. Louis County) a message box will pop up informing users that the Excel spreadsheet functionality will be retired as of the August 2016 script release (08/22/16) unless there is objection by county users. Users can comment on GitHub if they wish to request this functionality to continue at: https://github.com/MN-Script-Team/DHS-MAXIS-Scripts/issues/2373