### PR TITLE
Resolved #2480, Fset sanction updates

### DIFF
--- a/COMPLETE LIST OF SCRIPTS.vbs
+++ b/COMPLETE LIST OF SCRIPTS.vbs
@@ -142,7 +142,7 @@ script_array(script_num).script_name			= "FSET Sanction"
 script_array(script_num).description			= "Updates the WREG panel, and case notes when imposing or resolving a FSET sanction."
 script_array(script_num).category               = "ACTIONS"
 script_array(script_num).workflows              = ""
-script_array(script_num).subcategory            = array("")
+script_array(script_num).subcategory            = array("ABAWD")
 script_array(script_num).release_date           = #10/01/2000#
 
 script_num = script_num + 1								'Increment by one

--- a/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
+++ b/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
@@ -115,62 +115,55 @@ Call MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)
 
 'Initial dialog giving the user the option to select the type of sanction (imposed or resolved)
 Do	
-	Do	
-		Do
-			dialog SNAP_sanction_type_dialog
-			cancel_confirmation
-			If MAXIS_case_number = "" or IsNumeric(MAXIS_case_number) = False or len(MAXIS_case_number) > 8 then MsgBox "You need to type a valid case number."
-		Loop until MAXIS_case_number <> "" and IsNumeric(MAXIS_case_number) = True and len(MAXIS_case_number) <= 8
-		IF MAXIS_footer_month = "" OR MAXIS_footer_year = "" THEN MsgBox "You must enter both the footer month & footer year."
-	LOOP until (MAXIS_footer_month <> "" AND MAXIS_footer_year <> "")
-	IF sanction_type_droplist = "Select one..." THEN MsgBox "You must select either ""imposing sanction"" or ""resolving sanction""."
-LOOP until sanction_type_droplist <> "Select one..."
+	Do
+		err_msg = ""
+		dialog SNAP_sanction_type_dialog
+		cancel_confirmation
+		If MAXIS_case_number = "" or IsNumeric(MAXIS_case_number) = False or len(MAXIS_case_number) > 8 then err_msg = err_msg & vbnewline & "* Enter a valid case number."
+		IF len(MAXIS_footer_month) > 2 or isnumeric(NAXIS_footer_month) = FALSE then err_msg = err_msg & vbnewline & "* You must enter a valid 2 digit footer month."	'mandatory field
+		IF len(MAXIS_footer_year) > 2 or isnumeric(MAXIS_footer_year) = FALSE then err_msg = err_msg & vbnewline & "* You must enter a valid 2 digit footer year."		'mandatory field
+		IF sanction_type_droplist = "Select one..." then err_msg = err_msg & vbnewline & "* You must select either ""imposing sanction"" or ""resolving sanction""."
+		IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
+	LOOP UNTIL err_msg = ""									'loops until all errors are resolved
+	CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+Loop until are_we_passworded_out = false					'loops until user passwords back in
+
 'If worker selects to impose a sanction, they will get this dialog 
 If sanction_type_droplist = "Imposing sanction" THEN
-DO					
-	DO				
-		DO 			
-			DO
-				DO
-					Do
-						dialog SNAP_sanction_imposed_dialog
-						cancel_confirmation
-						If sanction_begin_date = "" THEN MsgBox "You must enter the date the sanction begins."
-					LOOP until sanction_begin_date <> ""
-					If HH_Member_Number = "" THEN MsgBox "You must enter the client's member number"
-				LOOP until HH_Member_Number <> ""
-				If number_of_sanction_droplist = "Select one..." THEN MsgBox "You must choose the number of sanctions."
-			LOOP until number_of_sanction_droplist <> "Select one..."
-			If sanction_reason_droplist = "Select one..." THEN MsgBox "You must choose the reason for the sanction."
-		LOOP until sanction_reason_droplist <> "Select one..."
-		If agency_informed_sanction = "" THEN MsgBox "You must enter the date the agency was informed of the sanction."
-	LOOP until agency_informed_sanction <> ""
-	If worker_signature = "" THEN MsgBox "You must sign your case note."
-LOOP until worker_signature <> ""
+	DO
+		Do
+			err_msg = ""
+			dialog SNAP_sanction_imposed_dialog
+			cancel_confirmation
+			If isdate(sanction_begin_date) = false then err_msg = err_msg & vbnewline & "* You must enter the date the sanction begins."
+			If isnumeric(HH_Member_Number) = False or len(HH_Member_Number) > 2 then err_msg = err_msg & vbnewline & "* You must enter the client's member number"
+			If number_of_sanction_droplist = "Select one..." then err_msg = err_msg & vbnewline & "* You must choose the number of sanctions."
+			If sanction_reason_droplist = "Select one..." THEN MsgBox "* You must choose the reason for the sanction."
+			If isdate(agency_informed_sanction) = False THEN MsgBox "* You must enter the date the agency was informed of the sanction."
+			If worker_signature = "" THEN MsgBox "* You must sign your case note."
+			IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
+		LOOP UNTIL err_msg = ""									'loops until all errors are resolved
+		CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+	Loop until are_we_passworded_out = false					'loops until user passwords back in
+	
 'If worker selects to resolve a sanction, they will get this dialog
 ELSEIf sanction_type_droplist = "Resolving sanction" THEN	
 	DO
-		Do
-			DO
-				DO	
-					DO
-						DO
-							dialog SNAP_sanction_resolved_dialog
-							cancel_confirmation
-							If sanction_end_date = "" THEN MsgBox "You must enter the date the sanction ends."
-						LOOP until sanction_end_date <> ""
-						If resolved_HH_Member_Number = "" THEN MsgBox "You must enter the client's member number"
-					LOOP until resolved_HH_Member_Number <> ""
-					If sanction_resolved_reason_droplist = "Select one..." THEN MsgBox "You must choose the reason the sanction has been resolved."
-				LOOP until sanction_resolved_reason_droplist <> "Select one..."
-				If ABAWD_status_droplist = "Select one..." THEN MsgBox "You must enter the ABAWD status."
-			LOOP until ABAWD_status_droplist <> "Select one..."
-			If worker_signature = "" THEN MsgBox "You must sign your case note."
-		LOOP until worker_signature <> ""
-		If(Exempt_FSET_WREG_droplist <> "Select one..." AND mandatory_WREG_exempt_FSET_droplist <> "Select one...") OR (Exempt_FSET_WREG_droplist = "Select one..." AND mandatory_WREG_exempt_FSET_droplist = "Select one...") THEN MsgBox "You must select only one of the options for the new FSET/WREG status."
-	LOOP until (Exempt_FSET_WREG_droplist = "Select one..." AND mandatory_WREG_exempt_FSET_droplist <> "Select one...") OR (Exempt_FSET_WREG_droplist <> "Select one..." AND mandatory_WREG_exempt_FSET_droplist = "Select one...")
-END If
-
+		DO
+			err_msg = ""
+			dialog SNAP_sanction_resolved_dialog
+			cancel_confirmation
+			If isdate(sanction_end_date) = False then err_msg = err_msg & vbnewline & "* You must enter the date the sanction ends."
+			If isnumeric(resolved_HH_Member_Number) = false or len(resolved_HH_Member_Number) <> 2 then err_msg = err_msg & vbnewline & "* You must enter the client's two-digit member number."
+			If sanction_resolved_reason_droplist = "Select one..." then err_msg = err_msg & vbnewline & "* You must choose the reason the sanction has been resolved."
+			If ABAWD_status_droplist = "Select one..." then err_msg = err_msg & vbnewline & "* You must enter the ABAWD status."
+			If worker_signature = "" then err_msg = err_msg & vbnewline & "* You must sign your case note."
+			If(Exempt_FSET_WREG_droplist <> "Select one..." AND mandatory_WREG_exempt_FSET_droplist <> "Select one...") OR (Exempt_FSET_WREG_droplist = "Select one..." AND mandatory_WREG_exempt_FSET_droplist = "Select one...") then err_msg = err_msg & vbnewline & "* You must select only one of the options for the new FSET/WREG status."
+			IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
+		LOOP UNTIL err_msg = ""									'loops until all errors are resolved
+		CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS
+	Loop until are_we_passworded_out = false					'loops until user passwords back in
+END IF
 'Confirming that we're in the correct footer month
 MAXIS_footer_month_confirmation	
 

--- a/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
+++ b/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
@@ -235,8 +235,8 @@ ELSEif sanction_type_droplist = "Resolving sanction" THEN
 	'checking to make sure HH MEMB is valid
 	EMWriteScreen resolved_HH_Member_Number, 20, 76
 	transmit
-	EMReadScreen WREG_MEMB_check, 7, 12, 2
-	IF WREG_MEMB_check = "REFERE" OR WREG_MEMB_check = "MEMBER " THEN script_end_procedure ("The member number that you entered is not valid.  Please check the member number, and start the script again.") 
+	EMReadScreen WREG_MEMB_check, 6, 12, 2
+	IF WREG_MEMB_check = "REFERE" OR WREG_MEMB_check = "MEMBER" THEN script_end_procedure ("The member number that you entered is not valid.  Please check the member number, and start the script again.") 
 	'if MEMB number is correct the WREG is updated
 	PF9
 	IF Exempt_FSET_WREG_droplist <> "Select one..." THEN EMWriteScreen Exempt_FSET_WREG_droplist, 8, 50

--- a/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
+++ b/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
@@ -221,8 +221,8 @@ If sanction_type_droplist = "Imposing sanction" THEN
 	EMWriteScreen HH_Member_Number, 20, 76
 	transmit
 	'checking to make sure that WREG is updating for the correct member
-	EMReadScreen WREG_MEMB_check, 7, 12, 2
-	IF WREG_MEMB_check = "REFERE" OR WREG_MEMB_check = "MEMBER " THEN script_end_procedure ("The member number that you entered is not valid.  Please check the member number, and start the script again.")
+	EMReadScreen WREG_MEMB_check, 6, 12, 2
+	IF WREG_MEMB_check = "REFERE" OR WREG_MEMB_check = "MEMBER" THEN script_end_procedure ("The member number that you entered is not valid.  Please check the member number, and start the script again.")
 	'if MEMB number is correct the WREG is updated
 	PF9
 	EMWriteScreen "02", 8, 50

--- a/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
+++ b/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
@@ -1,4 +1,3 @@
-'OPTION EXPLICIT
 'Required for statistical purposes==========================================================================================
 name_of_script = "ACTIONS - FSET SANCTION.vbs"
 start_time = timer
@@ -6,17 +5,6 @@ STATS_counter = 1                     	'sets the stats counter at one
 STATS_manualtime = 193                	'manual run time in seconds
 STATS_denomination = "C"       		'C is for each CASE
 'END OF stats block=========================================================================================================
-
-'DIM name_of_script
-'DIM start_time
-'DIM FuncLib_URL
-'DIM run_locally
-'DIM default_directory
-'DIM beta_agency
-'DIM req
-'DIM fso
-'DIM row
-'DIM col
 
 'LOADING FUNCTIONS LIBRARY FROM GITHUB REPOSITORY===========================================================================
 IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded once
@@ -50,59 +38,6 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 END IF
 'END FUNCTIONS LIBRARY BLOCK================================================================================================
 
-''SNAP_sanction_type_droplist dialog and other variables----------------------------------------------------------------------------------------------------
-'DIM ButtonPressed
-'DIM SNAP_sanction_type_dialog
-'DIM MAXIS_case_number
-'DIM MAXIS_footer_month
-'DIM MAXIS_footer_month
-'DIM MAXIS_footer_year
-'DIM MAXIS_footer_year
-'DIM worker_signature
-'DIM sanction_type_droplist
-'DIM ABAWD_status_check
-'DIM WREG_MEMB_check
-'MAXIS_footer_finder(MAXIS_footer_year, MAXIS_footer_month)
-''SNAP_sanction_imposed_dialog
-'DIM SNAP_sanction_imposed_dialog
-'DIM sanction_begin_date
-'DIM HH_Member_Number
-'DIM PWE_check
-'DIM number_of_sanction_droplist
-'DIM sanction_reason_droplist
-'DIM other_sanction_notes
-'DIM agency_informed_sanction
-'DIM WREG_sanction_droplist
-''SNAP_sanction_resolved_dialog
-'DIM SNAP_sanction_resolved_dialog
-'DIM sanction_end_date
-'DIM resolved_HH_Member_Number
-'DIM resolved_PWE_check
-'DIM sanction_resolved_reason_droplist
-'DIM sanction_resolution_droplist
-'DIM other_resolved_sanction_notes
-'DIM ABAWD_status_droplist
-'DIM Exempt_FSET_WREG_droplist
-'DIM mandatory_WREG_exempt_FSET_droplist
-'DIM FSET_orientation_date
-'DIM orientation_letter_check
-'DIM GA_basis_droplist
-
-
-'FUNCTION----------------------------------------------------------------------------------------------------
-FUNCTION MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)'Grabbing the footer month/year
-	Call find_variable("Month: ", MAXIS_footer_month, 2)
-	If isnumeric(MAXIS_footer_month) = true then 	'checking to see if a footer month 'number' is present 
-		MAXIS_footer_month = MAXIS_footer_month	
-		call find_variable("Month: " & MAXIS_footer_month & " ", MAXIS_footer_year, 2)
-		If isnumeric(MAXIS_footer_year) = true then MAXIS_footer_year = MAXIS_footer_year 'checking to see if a footer year 'number' is present
-	Else 'If we don’t have one found, we’re going to assign the current month/year.
-		MAXIS_footer_month = DatePart("m", date)   'Datepart delivers the month number to the variable
-		If len(MAXIS_footer_month) = 1 then MAXIS_footer_month = "0" & MAXIS_footer_month   'If it’s a single digit month, add a zero
-		MAXIS_footer_year = right(DatePart("yyyy", date), 2)	'We only need the right two characters of the year for MAXIS
-	End if
-END FUNCTION
-
 'The DIALOGS----------------------------------------------------------------------------------------------------
 BeginDialog SNAP_sanction_type_dialog, 0, 0, 171, 110, "SNAP Sanction type dialog					"
   EditBox 65, 10, 65, 15, MAXIS_case_number
@@ -116,7 +51,6 @@ BeginDialog SNAP_sanction_type_dialog, 0, 0, 171, 110, "SNAP Sanction type dialo
   Text 10, 10, 50, 15, "Case number: "
   Text 5, 50, 175, 10, "Are you imposing or resolving the FSET sanction?"
 EndDialog
-
 
 BeginDialog SNAP_sanction_imposed_dialog, 0, 0, 351, 170, "SNAP sanction imposed dialog"
   EditBox 95, 5, 55, 15, sanction_begin_date
@@ -140,7 +74,6 @@ BeginDialog SNAP_sanction_imposed_dialog, 0, 0, 351, 170, "SNAP sanction imposed
   Text 5, 50, 80, 10, "Reason for the sanction:"
   GroupBox 0, 125, 350, 40, "Per CM.0028.30.03"
 EndDialog
-
 
 BeginDialog SNAP_sanction_resolved_dialog, 0, 0, 346, 250, "SNAP sanction resolved dialog"
   EditBox 90, 10, 55, 15, sanction_end_date
@@ -173,7 +106,6 @@ BeginDialog SNAP_sanction_resolved_dialog, 0, 0, 346, 250, "SNAP sanction resolv
   Text 5, 15, 80, 10, "FSET sanction end date: "
 EndDialog
 
-
 'THE SCRIPT----------------------------------------------------------------------------------------------------
 'Connecting to MAXIS
 EMConnect ""
@@ -181,7 +113,6 @@ EMConnect ""
 Call MAXIS_case_number_finder(MAXIS_case_number)
 'Grabbing the footer month and footer year
 Call MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)
-
 
 'Initial dialog giving the user the option to select the type of sanction (imposed or resolved)
 Do	
@@ -282,8 +213,6 @@ END IF
 PF3
 PF3
 
-
-'LOGIC----------------------------------------------------------------------------------------------------
 'Logic to change the number_of_sanction_droplist into correct coding for the WREG panel
 IF number_of_sanction_droplist = "1st (1 month or until compliance, whichever is longer)" then number_of_sanction_droplist = "01"
 IF number_of_sanction_droplist = "2nd (3 months or until compliance, whichever is longer)" then number_of_sanction_droplist = "02"
@@ -293,7 +222,6 @@ IF number_of_sanction_droplist = "3rd (6 months or until compliance, whichever i
 GA_basis_droplist = Left(GA_basis_droplist, 2)
 
 CAll MAXIS_background_check
-'UPDATING THE WREG PANEL----------------------------------------------------------------------------------------------------
 'Updates WREG if sanction is imposed
 If sanction_type_droplist = "Imposing sanction" THEN 
 	Call navigate_to_MAXIS_screen("STAT", "WREG")
@@ -340,5 +268,4 @@ ELSEif sanction_type_droplist = "Resolving sanction" THEN
 	END IF	
 END IF
 
-'end message to worker reminding users to check notices
 script_end_procedure("Success, your case note been made and the WREG panel updated. Remember to approve your new results, and check your notice for accuracy.")

--- a/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
+++ b/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
@@ -221,7 +221,7 @@ If sanction_type_droplist = "Imposing sanction" THEN
 	EMWriteScreen HH_Member_Number, 20, 76
 	transmit
 	'checking to make sure that WREG is updating for the correct member
-	EMReadScreen WREG_MEMB_check, 6, 12, 2
+	EMReadScreen WREG_MEMB_check, 6, 24, 2
 	IF WREG_MEMB_check = "REFERE" OR WREG_MEMB_check = "MEMBER" THEN script_end_procedure ("The member number that you entered is not valid.  Please check the member number, and start the script again.")
 	'if MEMB number is correct the WREG is updated
 	PF9
@@ -235,7 +235,7 @@ ELSEif sanction_type_droplist = "Resolving sanction" THEN
 	'checking to make sure HH MEMB is valid
 	EMWriteScreen resolved_HH_Member_Number, 20, 76
 	transmit
-	EMReadScreen WREG_MEMB_check, 6, 12, 2
+	EMReadScreen WREG_MEMB_check, 6, 24, 2
 	IF WREG_MEMB_check = "REFERE" OR WREG_MEMB_check = "MEMBER" THEN script_end_procedure ("The member number that you entered is not valid.  Please check the member number, and start the script again.") 
 	'if MEMB number is correct the WREG is updated
 	PF9

--- a/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
+++ b/Script Files/ACTIONS/ACTIONS - FSET SANCTION.vbs
@@ -136,11 +136,11 @@ If sanction_type_droplist = "Imposing sanction" THEN
 			dialog SNAP_sanction_imposed_dialog
 			cancel_confirmation
 			If isdate(sanction_begin_date) = false then err_msg = err_msg & vbnewline & "* You must enter the date the sanction begins."
-			If isnumeric(HH_Member_Number) = False or len(HH_Member_Number) > 2 then err_msg = err_msg & vbnewline & "* You must enter the client's member number"
+			If isnumeric(HH_Member_Number) = False or len(HH_Member_Number) <> 2 then err_msg = err_msg & vbnewline & "* You must enter the client's two-digit member number"
 			If number_of_sanction_droplist = "Select one..." then err_msg = err_msg & vbnewline & "* You must choose the number of sanctions."
-			If sanction_reason_droplist = "Select one..." THEN MsgBox "* You must choose the reason for the sanction."
-			If isdate(agency_informed_sanction) = False THEN MsgBox "* You must enter the date the agency was informed of the sanction."
-			If worker_signature = "" THEN MsgBox "* You must sign your case note."
+			If sanction_reason_droplist = "Select one..." then err_msg = err_msg & vbnewline & "* You must choose the reason for the sanction."
+			If isdate(agency_informed_sanction) = False then err_msg = err_msg & vbnewline & "* You must enter the date the agency was informed of the sanction."
+			If worker_signature = "" then err_msg = err_msg & vbnewline & "* You must sign your case note."
 			IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect
 		LOOP UNTIL err_msg = ""									'loops until all errors are resolved
 		CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS


### PR DESCRIPTION
BLIP: Option added within the 'resolved sanction' option: If the recipient resolves their sanction prior to the sanction effective/imposed date, the case note reflects that the sanction was deleted, and the 'number of sanctions' field is cleared on STAT/WREG. The script has also moved from the MAIN ACTIONS menu to the ABAWD ACTIONS menu, and several functions and mandatory field criteria was updated on the back end.
