### PR TITLE
RESOLVES #2465 handles no edit mode, 10+ accounts, and other fixes

### DIFF
--- a/Script Files/ACTIONS/ACTIONS - ACCT PANEL UPDATER.vbs
+++ b/Script Files/ACTIONS/ACTIONS - ACCT PANEL UPDATER.vbs
@@ -38,7 +38,7 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 END IF
 'END FUNCTIONS LIBRARY BLOCK================================================================================================
 
-BeginDialog ACCT_UPDATERone, 0, 0, 146, 150, "ACCT UPDATERone"
+BeginDialog ACCT_UPDATERone, 0, 0, 146, 150, "ACCT UPDATER"
   EditBox 64, 4, 60, 16, MAXIS_case_number
   EditBox 64, 24, 20, 16, MAXIS_footer_month
   EditBox 104, 24, 20, 16, MAXIS_footer_year
@@ -58,102 +58,53 @@ EndDialog
 
 
 '***This dialog will not work in dialog editor due to the ACCT type being too long for the editor to handle.
-BeginDialog ACCT_UPDATERtwo, 0, 0, 206, 270, "ACCT UDATERtwo"
-  DropListBox 70, 25, 115, 15, "Select"+chr(9)+"SV - Savings"+chr(9)+"CK - Checking"+chr(9)+"CE - Certificate of Deposit"+chr(9)+"MM - Money Market"+chr(9)+"DC - Debit Card"+chr(9)+"KO - Keogh Acct"+chr(9)+"FT - Federal Thrift Savings Plan"+chr(9)+"SL - State * Local Govt Retirement and Certain Tax_Exemp Entities"+chr(9)+"RA - Employee Retirement Annuities"+chr(9)+"NP - Non-Profit Employer Ret Plans"+chr(9)+"IR - Individual Retirement Acct"+chr(9)+"RH - Roth IRA"+chr(9)+"FR - Retirement Plans for Certain Govt & Non-Govt Employers"+chr(9)+"CT - Corp Retirement Trust Prior to 6/25/1959"+chr(9)+"RT - Other Retirement Fund" +chr(9)+"QT - Qualified Tuition (529)"+chr(9)+"CA - Coverdell SV (530)"+chr(9)+"OE - Other Educational"+chr(9)+"OT - Other Account Type",ACCT_type
-  EditBox 70, 45, 90, 15, ACCT_number
-  EditBox 70, 65, 90, 15, ACCT_location
-  EditBox 55, 85, 55, 15, Balance
-  DropListBox 145, 85, 55, 15, "Select"+chr(9)+"1 - Bank Stmnt"+chr(9)+"2 - Agency Verif Form"+chr(9)+"3 - Coltrl Contact"+chr(9)+"5 - Other Doc"+chr(9)+"6 - Personal Stmnt"+chr(9)+"N - No Verif Provided", VERIF_type
-  EditBox 45, 110, 55, 15, as_of_date
-  EditBox 148, 110, 55, 15, date_recd
-  EditBox 80, 130, 30, 15, penalty
-  DropListBox 155, 130, 25, 15, " "+chr(9)+"Y"+chr(9)+"N", withdrawal_penalty_yes_no
-  DropListBox 125, 150, 60, 15, " "+chr(9)+"1 - Bank Stmnt"+chr(9)+"2 - Agency Verif Form"+chr(9)+"3 - Coltrl Contact"+chr(9)+"5 - Other Doc"+chr(9)+"6 - Personal Stmnt"+chr(9)+"N - No Verif Provided", penalty_verif
-  DropListBox 25, 185, 20, 10, " "+chr(9)+"Y"+chr(9)+"N", CASH_counts
-  DropListBox 60, 185, 20, 10, " "+chr(9)+"Y"+chr(9)+"N", FS_counts
-  DropListBox 100, 185, 20, 10, " "+chr(9)+"Y"+chr(9)+"N", HC_counts
-  DropListBox 145, 185, 20, 10, " "+chr(9)+"Y"+chr(9)+"N", GRH_counts
-  DropListBox 185, 185, 20, 10, " "+chr(9)+"Y"+chr(9)+"N", IVE_counts
-  DropListBox 70, 205, 30, 10, " "+chr(9)+"Yes"+chr(9)+"No", joint_owner
-  EditBox 155, 205, 10, 15, ratio_one
-  EditBox 175, 205, 10, 15, ratio_two
-  EditBox 100, 225, 20, 15, interest_month
-  EditBox 135, 225, 20, 15, interest_year
+BeginDialog ACCT_UPDATERtwo, 0, 0, 246, 270, "ACCT UDATER Dialog"
+  DropListBox 90, 25, 115, 15, "Select"+chr(9)+"SV - Savings"+chr(9)+"CK - Checking"+chr(9)+"CE - Certificate of Deposit"+chr(9)+"MM - Money Market"+chr(9)+"DC - Debit Card"+chr(9)+"KO - Keogh Acct"+chr(9)+"FT - Federal Thrift Savings Plan"+chr(9)+"SL - State * Local Govt Retirement and Certain Tax_Exemp Entities"+chr(9)+"RA - Employee Retirement Annuities"+chr(9)+"NP - Non-Profit Employer Ret Plans"+chr(9)+"IR - Individual Retirement Acct"+chr(9)+"RH - Roth IRA"+chr(9)+"FR - Retirement Plans for Certain Govt & Non-Govt Employers"+chr(9)+"CT - Corp Retirement Trust Prior to 6/25/1959"+chr(9)+"RT - Other Retirement Fund" +chr(9)+"QT - Qualified Tuition (529)"+chr(9)+"CA - Coverdell SV (530)"+chr(9)+"OE - Other Educational"+chr(9)+"OT - Other Account Type",ACCT_type
+  EditBox 90, 45, 90, 15, ACCT_number
+  EditBox 90, 65, 90, 15, ACCT_location
+  EditBox 70, 85, 55, 15, Balance
+  DropListBox 160, 85, 55, 15, "Select"+chr(9)+"1 - Bank Stmnt"+chr(9)+"2 - Agency Verif Form"+chr(9)+"3 - Coltrl Contact"+chr(9)+"5 - Other Doc"+chr(9)+"6 - Personal Stmnt"+chr(9)+"N - No Verif Provided", VERIF_type
+  EditBox 65, 110, 55, 15, as_of_date
+  EditBox 165, 110, 55, 15, date_recd
+  EditBox 100, 130, 30, 15, penalty
+  DropListBox 175, 130, 25, 15, " "+chr(9)+"Y"+chr(9)+"N", withdrawal_penalty_yes_no
+  DropListBox 145, 150, 60, 15, " "+chr(9)+"1 - Bank Stmnt"+chr(9)+"2 - Agency Verif Form"+chr(9)+"3 - Coltrl Contact"+chr(9)+"5 - Other Doc"+chr(9)+"6 - Personal Stmnt"+chr(9)+"N - No Verif Provided", penalty_verif
+  DropListBox 25, 185, 25, 15, " "+chr(9)+"Y"+chr(9)+"N", CASH_counts
+  DropListBox 70, 185, 25, 15, " "+chr(9)+"Y"+chr(9)+"N", FS_counts
+  DropListBox 115, 185, 25, 15, " "+chr(9)+"Y"+chr(9)+"N", HC_counts
+  DropListBox 165, 185, 25, 15, " "+chr(9)+"Y"+chr(9)+"N", GRH_counts
+  DropListBox 215, 185, 25, 15, " "+chr(9)+"Y"+chr(9)+"N", IVE_counts
+  DropListBox 95, 205, 30, 10, " "+chr(9)+"Yes"+chr(9)+"No", joint_owner
+  EditBox 180, 205, 10, 15, ratio_one
+  EditBox 200, 205, 10, 15, ratio_two
+  EditBox 125, 225, 20, 15, interest_month
+  EditBox 160, 225, 20, 15, interest_year
   ButtonGroup ButtonPressed
-    OkButton 5, 250, 50, 15
-  Text 15, 50, 50, 10, "ACCT Number:"
-  Text 10, 175, 175, 10, "Does the ACCT count towards the following programs:"
+    OkButton 65, 250, 50, 15
+  Text 35, 50, 50, 10, "ACCT Number:"
+  Text 30, 175, 175, 10, "Does the ACCT count towards the following programs:"
   Text 5, 190, 20, 10, "Cash:"
-  Text 45, 190, 15, 10, "FS:"
-  Text 80, 190, 15, 10, "HC:"
-  Text 120, 190, 20, 10, "GRH:"
-  Text 165, 190, 15, 10, "IV-E:"
-  Text 120, 90, 20, 10, "Verif:"
+  Text 55, 190, 15, 10, "FS:"
+  Text 100, 190, 15, 10, "HC:"
+  Text 145, 190, 20, 10, "GRH:"
+  Text 195, 190, 15, 10, "IV-E:"
+  Text 135, 90, 20, 10, "Verif:"
   ButtonGroup ButtonPressed
-    CancelButton 150, 250, 50, 15
-  Text 15, 155, 100, 10, "Withdrawl Penalty Verification:"
-  Text 5, 110, 40, 20, "As of Date: xx/xx/xx"
-  Text 5, 210, 60, 10, "Joint Owner (y/n):"
-  Text 15, 70, 50, 10, "ACCT Location:"
-  Text 110, 210, 45, 10, "Share Ratio:"
-  Text 15, 135, 65, 10, "Withdrawl Penalty:"
-  Text 170, 210, 5, 10, "/"
-  Text 15, 30, 40, 10, "ACCT type:"
-  Text 5, 230, 95, 10, "Next Interest Date: MM/YY"
-  Text 15, 90, 30, 10, "Balance:"
-  Text 125, 230, 5, 10, "/"
-  Text 125, 135, 25, 10, "Yes/No"
-  Text 15, 10, 145, 10, "Please enter all pertinent ACCT information."
-  Text 105, 110, 40, 20, "Date Rec'd: xx/xx/xx"
-EndDialog
-
-BeginDialog ACCT_UPDATERthree, 0, 0, 206, 270, "ACCT UPDATERthree"
-  EditBox 70, 25, 90, 15, ACCT_type
-  EditBox 70, 45, 90, 15, ACCT_number
-  EditBox 70, 65, 90, 15, ACCT_location
-  EditBox 55, 85, 55, 15, Balance
-  DropListBox 145, 85, 55, 15, "Select"+chr(9)+"1 - Bank Stmnt"+chr(9)+"2 - Agency Verif Form"+chr(9)+"3 - Coltrl Contact"+chr(9)+"5 - Other Doc"+chr(9)+"6 - Personal Stmnt"+chr(9)+"N - No Verif Provided", VERIF_type
-  EditBox 45, 110, 55, 15, as_of_date
-  EditBox 148, 110, 55, 15, date_recd
-  EditBox 80, 130, 30, 15, penalty
-  DropListBox 155, 130, 25, 15, " "+chr(9)+"Y"+chr(9)+"N", withdrawal_penalty_yes_no
-  EditBox 125, 150, 60, 15, penalty_verif
-  EditBox 25, 185, 20, 15, CASH_counts
-  EditBox 60, 185, 20, 15, FS_counts
-  EditBox 100, 185, 20, 15, HC_counts
-  EditBox 145, 185, 20, 15, GRH_counts
-  EditBox 185, 185, 20, 15, IVE_counts
-  EditBox 70, 205, 30, 15, joint_owner
-  EditBox 155, 205, 10, 15, ratio_one
-  EditBox 175, 205, 10, 15, ratio_two
-  EditBox 100, 225, 20, 15, interest_month
-  EditBox 135, 225, 20, 15, interest_year
-  ButtonGroup ButtonPressed
-    OkButton 5, 250, 50, 15
-  Text 15, 50, 50, 10, "ACCT Number:"
-  Text 10, 175, 175, 10, "Does the ACCT count towards the following programs:"
-  Text 5, 190, 20, 10, "Cash:"
-  Text 45, 190, 15, 10, "FS:"
-  Text 80, 190, 15, 10, "HC:"
-  Text 120, 190, 20, 10, "GRH:"
-  Text 165, 190, 15, 10, "IV-E:"
-  Text 120, 90, 20, 10, "Verif:"
-  ButtonGroup ButtonPressed
-    CancelButton 150, 250, 50, 15
-  Text 15, 155, 100, 10, "Withdrawl Penalty Verification:"
-  Text 5, 110, 40, 20, "As of Date: xx/xx/xx"
-  Text 5, 210, 60, 10, "Joint Owner (y/n):"
-  Text 15, 70, 50, 10, "ACCT Location:"
-  Text 110, 210, 45, 10, "Share Ratio:"
-  Text 15, 135, 65, 10, "Withdrawl Penalty:"
-  Text 170, 210, 5, 10, "/"
-  Text 15, 30, 40, 10, "ACCT type:"
-  Text 5, 230, 95, 10, "Next Interest Date: MM/YY"
-  Text 15, 90, 30, 10, "Balance:"
-  Text 125, 230, 5, 10, "/"
-  Text 125, 135, 25, 10, "Yes/No"
-  Text 15, 10, 145, 10, "Please enter all pertinent ACCT information."
-  Text 105, 110, 40, 20, "Date Rec'd: xx/xx/xx"
+    CancelButton 120, 250, 50, 15
+  Text 35, 155, 100, 10, "Withdrawl Penalty Verification:"
+  Text 25, 110, 40, 20, "As of Date: xx/xx/xx"
+  Text 30, 210, 60, 10, "Joint Owner (y/n):"
+  Text 35, 70, 50, 10, "ACCT Location:"
+  Text 135, 210, 45, 10, "Share Ratio:"
+  Text 35, 135, 65, 10, "Withdrawl Penalty:"
+  Text 195, 210, 5, 10, "/"
+  Text 35, 30, 40, 10, "ACCT type:"
+  Text 30, 230, 95, 10, "Next Interest Date: MM/YY"
+  Text 30, 90, 30, 10, "Balance:"
+  Text 150, 230, 5, 10, "/"
+  Text 145, 135, 25, 10, "Yes/No"
+  Text 45, 10, 145, 10, "Please enter all pertinent ACCT information."
+  Text 125, 110, 40, 20, "Date Rec'd: xx/xx/xx"
 EndDialog
 
 BeginDialog DoneUpdating, 0, 0, 114, 74, "DoneUpdating"
@@ -232,6 +183,15 @@ DO
 
 		CALL check_for_MAXIS(False)
 
+		'navigates to get program data to determine which count values are required
+		call navigate_to_MAXIS_screen("stat", "prog")
+		EMReadScreen CASH1_status, 4, 6, 74
+		EMReadScreen CASH2_status, 4, 7, 74
+		EMReadScreen GRH_status, 4, 9, 74
+		EMReadScreen SNAP_status, 4, 10, 74
+		EMReadScreen IV-E_status, 4, 11, 74
+		EMReadScreen HC_status, 4, 12, 74
+
 		'navigates to STAT/ACCT
 		call navigate_to_MAXIS_screen("stat", "acct")			
 						
@@ -270,15 +230,15 @@ DO
 			'checks if there is a withdrawl penalty has been entered. **check is commented out currently.
 			'IF withdrawal_penalty_yes_no = " " THEN err_msg = err_msg & vbCr & "You must enter if there is a withdrawal penalty."
 			'checks if the CASH counts has been entered.
-			IF CASH_counts = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for Cash."
+			IF (CASH_counts = " " AND CASH1_status = "ACTV") OR (CASH_counts = " " AND CASH1_status = "PEND") OR (CASH_counts = " " AND CASH2_status = "ACTV") OR (CASH_counts = " " AND CASH2_status = "PEND") THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for Cash."
 			'checks if the FS counts has been entered.
-			IF FS_counts = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for SNAP."
+			IF (FS_counts = " " AND SNAP_status = "ACTV") OR (FS_counts = " " AND SNAP_status = "PEND") THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for SNAP."
 			'checks if the HC counts has been entered.
-			IF HC_counts = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for Health Care."
+			IF (HC_counts = " " AND HC_status = "ACTV") OR (HC_counts = " " AND HC_status = "PEND") THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for Health Care."
 			'checks if the GRH counts has been entered.
-			IF GRH_counts = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for GRH."
+			IF (GRH_counts = " " AND GRH_status = "ACTV") OR (GRH_counts = " " AND GRH_status = "PEND") THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for GRH."
 			'checks if the IVE counts has been entered.
-			IF IVE_counts = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for IVE."
+			IF (IVE_counts = " " AND IV-E_status = "ACTV") OR (IVE_counts = " " AND IV-E_status = "PEND") THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for IVE."
 			'checks if joint owner has been entered.
 			IF joint_owner = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT is a joint acct."
 			'checks if ratio one has been entered.
@@ -289,8 +249,12 @@ DO
 			IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbCr & err_msg & vbCr & vbCr & "Please resolve for the script to continue."
 		LOOP UNTIL err_msg = ""
 
-		EMWriteScreen "nn", 20, 79 							
+		EMWriteScreen "nn", 20, 79 	
 		transmit	
+		
+		EMReadScreen max_panel_check, 4, 24, 2 'This is just in case someone tries to create a 97th panel, 96 is currently the max for ACCT. 
+		IF max_panel_check = "ONLY" THEN script_end_procedure("There are the max number of panels for this Household member. Please review or delete and try again.")					
+
 
 		'Enters the ACCT type.
 		EMWriteScreen ACCT_type, 06, 44
@@ -341,6 +305,15 @@ DO
 
 	call check_for_MAXIS(false)
 
+		'navigates to get program data to determine which count values are required
+		call navigate_to_MAXIS_screen("stat", "prog")
+		EMReadScreen CASH1_status, 4, 6, 74
+		EMReadScreen CASH2_status, 4, 7, 74
+		EMReadScreen GRH_status, 4, 9, 74
+		EMReadScreen SNAP_status, 4, 10, 74
+		EMReadScreen IV-E_status, 4, 11, 74
+		EMReadScreen HC_status, 4, 12, 74
+
 		'navigates to STAT/ACCT
 		call navigate_to_MAXIS_screen("stat", "acct")
 						
@@ -358,14 +331,14 @@ DO
 
 
 		'Checks to make sure there are ACCT panels for this member. If none exist the script will close
-		EMReadScreen total_amt_of_panels, 1, 2, 78
-		If total_amt_of_panels = "0" then script_end_procedure("No ACCT panels exist for this client. Please restart the script and select ADD an ACCT panel or select the correct HHLD member number to update. The script will now stop.") & end_excel_and_script
+		EMReadScreen total_amt_of_panels, 2, 2, 78
+		If total_amt_of_panels = " 0" then script_end_procedure("No ACCT panels exist for this client. Please restart the script and select ADD an ACCT panel or select the correct HHLD member number to update. The script will now stop.") & end_excel_and_script
 		
 
 		'If there is more than one panel, this part will grab ACCT info off of them and present it to the worker to decide which one to use.
-		If total_amt_of_panels <> "0" then
+		If total_amt_of_panels <> " 0" then
 			Do
-				EMReadScreen current_panel_number, 1, 2, 73
+				EMReadScreen current_panel_number, 2, 2, 73
 				EMReadScreen account_location, 30, 8, 44
 				EMReadScreen account_type, 2, 6, 44
 				account_check = MsgBox("Is this the ACCT you want to update? Account location : " & trim(replace(account_location, "_", "")), 3)
@@ -382,30 +355,28 @@ DO
 				transmit
 			Loop until current_panel_number = total_amt_of_panels
 
-		'pulling ACCT info from MAXIS
-         	EMReadScreen ACCT_type, 2, 6, 44
-         	EMReadScreen ACCT_number, 20, 7, 44
-        	EMReadScreen ACCT_location, 20, 8, 44
-          	EMReadScreen Balance, 8, 10, 46
-          	EMReadScreen VERIF_type, 10, 10, 64
-          	EMReadScreen as_of_date, 8, 11, 44
-          	as_of_date = replace(as_of_date, " ", "/")
-          	EMReadScreen penalty, 8, 12, 46
-          	EMReadScreen withdrawal_penalty_yes_no, 1, 12, 64
-         	EMReadScreen penalty_verif, 1, 12, 72
-          	EMReadScreen CASH_counts, 1, 14, 50
-          	EMReadScreen FS_counts, 1, 14, 57
-          	EMReadScreen HC_counts, 1, 14, 64
-          	EMReadScreen GRH_counts, 1, 14, 72
-          	EMReadScreen IVE_counts, 1, 14, 80
-          	EMReadScreen joint_owner, 1, 15, 44
-          	EMReadScreen ratio_one, 1, 15, 76
-          	EMReadScreen ratio_two, 1, 15, 80
-          	EMReadScreen interest_month, 2, 17, 57
-          	EMReadScreen interest_year, 2, 17, 60
-		EMReadScreen panel_number, 8, 2, 72
-
-
+			'pulling ACCT info from MAXIS
+	         	EMReadScreen ACCT_type, 2, 6, 44
+	         	EMReadScreen ACCT_number, 20, 7, 44
+	        	EMReadScreen ACCT_location, 20, 8, 44
+	          	EMReadScreen Balance, 8, 10, 46
+    	      	EMReadScreen VERIF_type, 1, 10, 64
+    	      	EMReadScreen as_of_date, 8, 11, 44
+    	      	as_of_date = replace(as_of_date, " ", "/")
+    	      	EMReadScreen penalty, 8, 12, 46
+	          	EMReadScreen withdrawal_penalty_yes_no, 1, 12, 64
+	         	EMReadScreen penalty_verif, 1, 12, 72	
+	          	EMReadScreen CASH_counts, 1, 14, 50
+	          	EMReadScreen FS_counts, 1, 14, 57
+	          	EMReadScreen HC_counts, 1, 14, 64
+	          	EMReadScreen GRH_counts, 1, 14, 72	
+	          	EMReadScreen IVE_counts, 1, 14, 80
+	          	EMReadScreen joint_owner, 1, 15, 44
+	          	EMReadScreen ratio_one, 1, 15, 76
+	          	EMReadScreen ratio_two, 1, 15, 80
+	          	EMReadScreen interest_month, 2, 17, 57
+	          	EMReadScreen interest_year, 2, 17, 60
+			EMReadScreen panel_number, 8, 2, 72
 
 			'cleaning up the ACCT variables
 			ACCT_number = replace(ACCT_number, "_", "")
@@ -414,12 +385,31 @@ DO
 			ACCT_location = trim(ACCT_location)
 			Balance = replace(Balance, "_", "")
 			Balance = trim(Balance)
+			VERIF_type = replace(VERIF_type, "_", "")
+			VERIF_type = trim(VERIF_type)
+			'Formatting balance verif
+			IF VERIF_type = "1" THEN VERIF_type = "1 - Bank Stmnt"
+			IF VERIF_type = "2" THEN VERIF_type = "2 - Agency Verif Form"
+			IF VERIF_type = "3" THEN VERIF_type = "3 - Coltrl Contact"
+			IF VERIF_type = "5" THEN VERIF_type = "5 - Other Doc"
+			IF VERIF_type = "6" THEN VERIF_type = "6 - Personal Stmnt"
+			IF VERIF_type = "N" THEN VERIF_type = "N - No Verif Provided"
 			penalty = replace(penalty, "_", "")
 			penalty = trim(penalty)
 			withdrawal_penalty_yes_no = replace(withdrawal_penalty_yes_no, "_", "")
 			withdrawal_penalty_yes_no = trim(withdrawal_penalty_yes_no)
+			'formatting withdrawal_penalty_yes_no
+			IF withdrawal_penalty_yes_no = "Y" THEN withdrawal_penalty_yes_no = "Yes"
+			IF withdrawal_penalty_yes_no = "N" THEN withdrawal_penalty_yes_no = "No"
 			penalty_verif = replace(penalty_verif, "_", "")
 			penalty_verif = trim(penalty_verif)
+			'formatting withdrawl penalty verif code
+			IF penalty_verif = "1" THEN penalty_verif = "1 - Bank Stmnt"
+			IF penalty_verif = "2" THEN penalty_verif = "2 - Agency Verif Form"
+			IF penalty_verif = "3" THEN penalty_verif = "3 - Coltrl Contact"
+			IF penalty_verif = "5" THEN penalty_verif = "5 - Other Doc"
+			IF penalty_verif = "6" THEN penalty_verif = "6 - Personal Stmnt"
+			IF penalty_verif = "N" THEN penalty_verif = "N - No Verif Provided"
 			CASH_counts = replace(CASH_counts, "_", "")
 			CASH_counts = trim(CASH_counts)
 			FS_counts = replace(FS_counts, "_", "")
@@ -432,6 +422,9 @@ DO
 			IVE_counts = trim(IVE_counts)
 			joint_owner = replace(joint_owner, "_", "")
 			joint_owner = trim(joint_owner)
+			'formatting joint_owner
+			IF joint_owner = "Y" THEN joint_owner = "Yes"
+			IF joint_owner = "N" THEN joint_owner = "No"
 			ratio_one = replace(ratio_one, "_", "")
 			ratio_one = trim(ratio_one)
 			ratio_two = replace(ratio_two, "_", "")
@@ -441,14 +434,33 @@ DO
 			interest_year = replace(interest_year, "_", "")
 			interest_year = trim(interest_year)
 			panel_number = trim(panel_number)
-
-				If ACCT_type <> "__" then variable_written_to = variable_written_to & ACCT_type & ACCT_number & ACCT_location & Balance & penalty & withdrawal_penalty_yes_no & penalty_verif & CASH_counts & FS_counts & HC_counts & GRH_counts & IVE_counts & joint_owner & ratio_one & ratio_two & interest_month & interest_year & "; "
-				END IF
+			'Formatting account type
+			IF ACCT_type = "SV" THEN ACCT_type = "SV - Savings"
+			IF ACCT_type = "CK" THEN ACCT_type = "CK - Checking"
+			IF ACCT_type = "CE" THEN ACCT_type = "CE - Certificate of Deposit"
+			IF ACCT_type = "MM" THEN ACCT_type = "MM - Money Market"
+			IF ACCT_type = "DC" THEN ACCT_type = "DC - Debit Card"
+			IF ACCT_type = "KO" THEN ACCT_type = "KO - Keogh Acct"
+			IF ACCT_type = "FT" THEN ACCT_type = "FT - Federal Thrift Savings Plan"
+			IF ACCT_type = "SL" THEN ACCT_type = "SL - State * Local Govt Retirement and Certain Tax_Exemp Entities"
+			IF ACCT_type = "RA" THEN ACCT_type = "RA - Employee Retirement Annuities"
+			IF ACCT_type = "NP" THEN ACCT_type = "NP - Non-Profit Employer Ret Plans"
+			IF ACCT_type = "IR" THEN ACCT_type = "IR - Individual Retirement Acct"
+			IF ACCT_type = "RH" THEN ACCT_type = "RH - Roth IRA"
+			IF ACCT_type = "FR" THEN ACCT_type = "FR - Retirement Plans for Certain Govt & Non-Govt Employers"
+			IF ACCT_type = "CT" THEN ACCT_type = "CT - Corp Retirement Trust Prior to 6/25/1959"
+			IF ACCT_type = "RT" THEN ACCT_type = "RT - Other Retirement Fund"
+			IF ACCT_type = "QT" THEN ACCT_type = "QT - Qualified Tuition (529)"
+			IF ACCT_type = "CA" THEN ACCT_type = "CA - Coverdell SV (530)"
+			IF ACCT_type = "OE" THEN ACCT_type = "OE - Other Educational"
+			IF ACCT_type = "OT" THEN ACCT_type = "OT - Other Account Type"
+			If ACCT_type <> "__" then variable_written_to = variable_written_to & ACCT_type & ACCT_number & ACCT_location & Balance & penalty & withdrawal_penalty_yes_no & penalty_verif & CASH_counts & FS_counts & HC_counts & GRH_counts & IVE_counts & joint_owner & ratio_one & ratio_two & interest_month & interest_year & "; "
+		END IF
 
 		DO
 			err_msg = ""
 			'starts the ACCT Panel Updater dialog
-			Dialog ACCT_UPDATERthree
+			Dialog ACCT_UPDATERtwo
 			'asks if you want to cancel and if "yes" is selected sends StopScript and closes excel
 			If ButtonPressed = 0 then end_excel_and_script
 			cancel_confirmation 
@@ -469,15 +481,15 @@ DO
 			'checks if there is a withdrawl penalty has been entered. **check is commented out currently.
 			'IF withdrawal_penalty_yes_no = " " THEN err_msg = err_msg & vbCr & "You must enter if there is a withdrawal penalty."
 			'checks if the CASH counts has been entered.
-			IF CASH_counts = "" THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for Cash."
+			IF (CASH_counts = " " AND CASH1_status = "ACTV") OR (CASH_counts = " " AND CASH1_status = "PEND") OR (CASH_counts = " " AND CASH2_status = "ACTV") OR (CASH_counts = " " AND CASH2_status = "PEND") THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for Cash."
 			'checks if the FS counts has been entered.
-			IF FS_counts = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for SNAP."
+			IF (FS_counts = " " AND SNAP_status = "ACTV") OR (FS_counts = " " AND SNAP_status = "PEND") THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for SNAP."
 			'checks if the HC counts has been entered.
-			IF HC_counts = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for Health Care."
+			IF (HC_counts = " " AND HC_status = "ACTV") OR (HC_counts = " " AND HC_status = "PEND") THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for Health Care."
 			'checks if the GRH counts has been entered.
-			IF GRH_counts = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for GRH."
+			IF (GRH_counts = " " AND GRH_status = "ACTV") OR (GRH_counts = " " AND GRH_status = "PEND") THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for GRH."
 			'checks if the IVE counts has been entered.
-			IF IVE_counts = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for IVE."
+			IF (IVE_counts = " " AND IV-E_status = "ACTV") OR (IVE_counts = " " AND IV-E_status = "PEND") THEN err_msg = err_msg & vbCr & "You must enter if the ACCT counts for IVE."
 			'checks if joint owner has been entered.
 			IF joint_owner = " " THEN err_msg = err_msg & vbCr & "You must enter if the ACCT is a joint acct."
 			'checks if ratio one has been entered.
@@ -489,6 +501,9 @@ DO
 		LOOP UNTIL err_msg = ""
 
 	PF9
+	'checking to see if we got into edit mode. 
+	EMReadScreen edit_mode_check, 1, 20, 8
+	If edit_mode_check = "D" then script_end_procedure("Unable to create a new JOBS panel. Check which member number you provided. Otherwise you may be in inquiry mode. If so switch to production and try again. Or try closing BlueZone.")
 
 	'Assigns a value to Balance_cleanup to clear out the balance field prior to entering info from the script.
 	Balance_cleanup = "        "


### PR DESCRIPTION
BLIP: Script will now warn users if unable to edit, it can update if there are more than 9 account panels. Also implemented some behind the scenes revamping including:

- deleted extraneous dialog
- script will now convert what it finds on ACCT panel for all variables on the dialog
- new handling no longer requiring to enter count codes for programs that aren't active/pending
