### PR TITLE
Resolved #2479, Banked months report enhancements

### DIFF
--- a/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
+++ b/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
@@ -1,3 +1,5 @@
+'Hard coding that needs to be updated each year: MAXIS_footer_year, counted_date_year 
+
 'STATS GATHERING----------------------------------------------------------------------------------------------------
 name_of_script = "BULK - BANKED MONTHS REPORT.vbs"
 start_time = timer
@@ -299,13 +301,14 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 					Banked_Month_Client_Array(send_to_DHS, item) = FALSE	'Removing this client from DHS report - reason on next line'
 					Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded,item) & "SNAP is prorated in " & MAXIS_footer_month & "/" & MAXIS_footer_year & " | "
 				Else
+					'This section checks for cases that were not approved as PRORATED, but are prorated for the report date on the PROG panel
 					Call navigate_to_MAXIS_screen("STAT", "PROG")
 					EMReadScreen elig_month, 2, 10, 44
 					EMReadScreen elig_date, 2, 10, 47
 					EMReadScreen elig_year, 2, 10, 50
 					prorated_date = elig_month & "/" & elig_year		'creating date variables to measure against report month
 					If prorated_date = report_date then 
-						If elig_date <> "01" then 
+						If elig_date <> "01" then 	
 							Banked_Month_Client_Array(send_to_DHS, item) = FALSE	'Removing this client from DHS report - reason on next line'
 							Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded,item) & "SNAP is prorated in " & MAXIS_footer_month & "/" & MAXIS_footer_year & " | "
 						END if
@@ -582,7 +585,7 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 		IF wreg_total <> "0" THEN
 			EmWriteScreen "x", 13, 57		'Pulls up the WREG tracker'
 			transmit
-			EMREADScreen tracking_record_check, 15, 4, 40  
+			EMREADScreen tracking_record_check, 15, 4, 40  		'adds cases to the rejection list if the ABAWD tracking record cannot be accessed.
 			If tracking_record_check <> "Tracking Record" then 
 				Banked_Month_Client_Array(send_to_DHS,     item) = FALSE	'Removing this client from DHS report - reason on next line'
 				Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded, item) & "Unable to access the ABAWD tracking record. Review manually. | "
@@ -606,7 +609,7 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 					If bene_mo_col = "55" then counted_date_month = "10"
 					If bene_mo_col = "59" then counted_date_month = "11"
 					If bene_mo_col = "63" then counted_date_month = "12"
-					'counted date year
+					'counted date year: this is found on rows 7-11. Row 11 is current year plus one, so this will be exclude this list.
 					If bene_yr_row = "10" then counted_date_year = right(DatePart("yyyy", date), 2)
 					If bene_yr_row = "9"  then counted_date_year = right(DatePart("yyyy", DateAdd("yyyy", -1, date)), 2)
 					If bene_yr_row = "8"  then counted_date_year = right(DatePart("yyyy", DateAdd("yyyy", -2, date)), 2)
@@ -666,7 +669,7 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 		
 		'Reading the person notes regarding which months are counted as banked months
 		PF5			'navigates to Person note from WREG PANEL
-		'adds case to the rejected list if cannot person note
+		'adds case to the rejected list if cannot access the person notes screen. This is usually for INACTIVE cases or out-of-county cases. 
 		EMReadScreen person_note_confirmation, 12, 2, 31
 		If person_note_confirmation <> "Person Notes" then 
 			Banked_Month_Client_Array(send_to_DHS, item) = False	'Removing this client from DHS report - reason on next line'

--- a/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
+++ b/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
@@ -570,11 +570,16 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 		IF wreg_total <> "0" THEN
 			EmWriteScreen "x", 13, 57		'Pulls up the WREG tracker'
 			transmit
-			bene_mo_col = (15 + (4*cint(MAXIS_footer_month)))		'col to search starts at 15, increased by 4 for each footer month
-			bene_yr_row = 10
+			EMREADScreen tracking_record_check, 15, 4, 40  
+			If tracking_record_check <> "Tracking Record" then 
+				Banked_Month_Client_Array(send_to_DHS,     item) = FALSE	'Removing this client from DHS report - reason on next line'
+				Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded, item) & "Unable to access the ABAWD tracking record. Review manually. | "
+			ELSE 
+				bene_mo_col = (15 + (4*cint(MAXIS_footer_month)))		'col to search starts at 15, increased by 4 for each footer month
+				bene_yr_row = 10
 				abawd_counted_months = 0					'delclares the variables values at 0
 				second_abawd_period = 0
-			month_count = 0
+				month_count = 0
 				DO
 					'establishing variables for specific ABAWD counted month dates
 					If bene_mo_col = "19" then counted_date_month = "01"
@@ -630,9 +635,10 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 					month_count = month_count + 1
 				LOOP until month_count = 36
 			PF3
+			End if
 		END If
 		'END OF ABAWD MONTHS AND SECOND ABAWD MONTHS----------------------------------------------------------------------------------------------------
-
+		
 		'Reading the person notes regarding which months are counted as banked months
 		PF5			'navigates to Person note from WREG PANEL
 		'adds case to the rejected list if cannot person note
@@ -716,16 +722,19 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 				END IF			
 			END IF
 			PF3 'exits person note'
-		
+			
 			'clears values of the following variables 
 			abawd_counted_months_string = ""
 			abawd_info_list = ""
 			second_counted_months_string = ""
 			second_set_info_list = ""
 			banked_months_list = ""
+			abawd_counted_months = ""
+			second_abawd_period = ""
 		End If
 	END If
 Next	
+
 '-----------------------------------END OF WREG PIECE---------------------------------------------------------------
 'Dialog to select the file that users will send to DHS 
 BeginDialog DHS_Report_Dialog, 0, 0, 226, 65, "DHS Banked Months"

--- a/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
+++ b/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
@@ -42,6 +42,8 @@ EMConnect ""		'connecting to MAXIS
 Call get_county_code	'gets county name to input into the 1st col of the spreadsheet
 developer_mode_checkbox = checked 	'defauting the person note option to NOT person note
 
+report_date = MAXIS_footer_month & "/" & MAXIS_footer_year			'creating date variables to measure against person note counted dates
+
 'Runs the dialog'
 Do
 	Do
@@ -296,7 +298,23 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 				IF fs_prorated = "Prorated" Then
 					Banked_Month_Client_Array(send_to_DHS, item) = FALSE	'Removing this client from DHS report - reason on next line'
 					Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded,item) & "SNAP is prorated in " & MAXIS_footer_month & "/" & MAXIS_footer_year & " | "
-				End If
+				Else
+					Call navigate_to_MAXIS_screen("STAT", "PROG")
+					EMReadScreen elig_month, 2, 10, 44
+					EMReadScreen elig_date, 2, 10, 47
+					EMReadScreen elig_year, 2, 10, 50
+					report_date = MAXIS_footer_month & "/" & MAXIS_footer_year			'creating date variables to measure against report month
+				
+					'handling for cases that do not have a completed HCRE panel
+	    			PF3		'exits PROG to prommpt HCRE if HCRE insn't complete
+	    			Do
+	    				EMReadscreen HCRE_panel_check, 4, 2, 50
+						If HCRE_panel_check = "HCRE" then 
+	                    	PF10	'exists edit mode in cases where HCRE isn't complete for a member
+	    					PF3
+	    				END IF
+	    			Loop until HCRE_panel_check <> "HCRE"
+				END IF
 			END If
 		'///////SCRIPT WILL NOW CHECK FOR POSSIBLE EXPEMTIONS FOR CLIENT'
 		'Age exemption'
@@ -529,8 +547,7 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 
 		'//////////WREG PORTION//////////////////////////////////////////////
 		'This is intense, the script is going to check every line on the WREG tracker to list all of the counted ABAWD months for the report'
-		report_date = MAXIS_footer_month & "/" & MAXIS_footer_year			'creating date variables to measure against person note counted dates
-
+		
 		Call navigate_to_MAXIS_screen("stat","wreg")		'navigates to stat/wreg
 		EMWriteScreen Banked_Month_Client_Array(memb_num, item), 20, 76
 		transmit

--- a/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
+++ b/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
@@ -631,7 +631,6 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 					If left(second_set_info_list, 1) = "," then second_set_info_list = right(second_set_info_list, len(second_set_info_list) - 1)
 					second_months_array = Split(second_set_info_list,",")
 					 
-			
 					bene_mo_col = bene_mo_col - 4		're-establishing serach once the end of the row is reached
 					IF bene_mo_col = 15 THEN
 						bene_yr_row = bene_yr_row - 1
@@ -639,7 +638,6 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 					END IF
 					month_count = month_count + 1
 				LOOP until month_count = 36
-			msgbox "end of abawd case" & vbcr & abawd_counted_months & vbCr & abawd_info_list & vbCr & "report date" & report_date
 			PF3
 			End if
 		END If
@@ -726,8 +724,7 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 						END IF
 					END IF 
 				END IF			
-			END IF
-			msgbox "end of pers case" & vbcr & abawd_counted_months & vbCr & abawd_info_list & vbCr & "report date" & report_date
+			END If
 			PF3 'exits person note'
 			
 			'clears values of the following variables 

--- a/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
+++ b/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
@@ -303,8 +303,13 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 					EMReadScreen elig_month, 2, 10, 44
 					EMReadScreen elig_date, 2, 10, 47
 					EMReadScreen elig_year, 2, 10, 50
-					report_date = MAXIS_footer_month & "/" & MAXIS_footer_year			'creating date variables to measure against report month
-				
+					prorated_date = elig_month & "/" & elig_year		'creating date variables to measure against report month
+					If prorated_date = report_date then 
+						If elig_date <> "01" then 
+							Banked_Month_Client_Array(send_to_DHS, item) = FALSE	'Removing this client from DHS report - reason on next line'
+							Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded,item) & "SNAP is prorated in " & MAXIS_footer_month & "/" & MAXIS_footer_year & " | "
+						END if
+					END IF 
 					'handling for cases that do not have a completed HCRE panel
 	    			PF3		'exits PROG to prommpt HCRE if HCRE insn't complete
 	    			Do

--- a/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
+++ b/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
@@ -655,26 +655,35 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 
 		'Write a new person note only for cases that are being sent to DHS on the 'true' list 
 		If (developer_mode_checkbox = unchecked AND Banked_Month_Client_Array(send_to_DHS, item) = True) then 
-			PF5
-			EMreadscreen edit_mode_required_check, 6, 5, 3		'if not person not exists, person note goes directly into edit mode
-			If edit_mode_required_check = "      " then 
-				EMWriteScreen "Banked Month Used " & report_date, 5, 3
-				EMWriteScreen "Case has been counted and reported to DHS.", 6, 3 
-			ElseIF edit_mode_required_check <> "      " then 	
-				'creating a Do loop to ensure that duplicate person notes are not being made
-				PNOTE_row = 5		'establishes the row to start searching the Person notes from
-				Do
-					EMReadScreen counted_banked_month, 12, PNOTE_row, 31
-					If counted_banked_month = "Banked Month" then EMReadScreen abawd_counted_months_string, 5, PNOTE_row, 49
-					If abawd_counted_months_string = report_date then exit do	'if person note has already been made for the report date, then does not person note
-					PNOTE_row = PNOTE_row + 1	'adds incremental to row to search
-				LOOP until PNOTE_row = 18
-				If PNOTE_row = 18 then 
-					PF9
+			PF5		'enters person note screen
+			
+			'adds case to the rejected list if cannot person note
+			EMReadScreen person_note_confirmation, 12, 2, 31
+			If person_note_confirmation <> "Person Notes" then 
+				Banked_Month_Client_Array(send_to_DHS, item) = False	'Removing this client from DHS report - reason on next line'
+				Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded, item) & "Unable to person note this case. Case may be in another county. | "
+			ELSE 
+				'if not person not exists, person note goes directly into edit mode
+				EMreadscreen edit_mode_required_check, 6, 5, 3		
+				If edit_mode_required_check = "      " then 
 					EMWriteScreen "Banked Month Used " & report_date, 5, 3
 					EMWriteScreen "Case has been counted and reported to DHS.", 6, 3 
-				END IF
-			END IF 
+				ElseIF edit_mode_required_check <> "      " then 	
+					'creating a Do loop to ensure that duplicate person notes are not being made
+					PNOTE_row = 5		'establishes the row to start searching the Person notes from
+					Do
+						EMReadScreen counted_banked_month, 12, PNOTE_row, 31
+						If counted_banked_month = "Banked Month" then EMReadScreen abawd_counted_months_string, 5, PNOTE_row, 49
+						If abawd_counted_months_string = report_date then exit do	'if person note has already been made for the report date, then does not person note
+						PNOTE_row = PNOTE_row + 1	'adds incremental to row to search
+					LOOP until PNOTE_row = 18
+					If PNOTE_row = 18 then 
+						PF9
+						EMWriteScreen "Banked Month Used " & report_date, 5, 3
+						EMWriteScreen "Case has been counted and reported to DHS.", 6, 3 
+					END IF
+				END IF 
+			END IF			
 		END IF
 		PF3 'exits person note'
 		

--- a/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
+++ b/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
@@ -536,10 +536,14 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 		transmit
 		EMReadScreen wreg_code,  2, 8,  50
 		EMReadScreen abawd_code, 2, 13, 50
-		IF wreg_code <> "30" AND abawd_code <> "10" Then	'ALL Banked Month clients should have WREG coded 30-10'
+		IF wreg_code <> "30" Then	'ALL Banked Month clients should have WREG coded 30-10'
 			Banked_Month_Client_Array(send_to_DHS,     item) = FALSE	'Removing this client from DHS report - reason on next line'
-			Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded, item) & "WREG is not coded 30-10. Review. | "
-		End If
+			Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded, item) & "WREG code is not a 30 (Mandatory FSET participant). Review. | "
+		Elseif abawd_code <> "10" then 			'this is to make sure that 30/11 (second set cases) are removed from the report for the report month
+			Banked_Month_Client_Array(send_to_DHS,     item) = FALSE	'Removing this client from DHS report - reason on next line'
+			Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded, item) & "ABAWD code is not a 10 (ABAWD counted month). Review. | "
+		END if
+			
 		EMReadScreen wreg_total, 1, 2, 78
 		IF wreg_total <> "0" THEN
 			EmWriteScreen "x", 13, 57		'Pulls up the WREG tracker'

--- a/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
+++ b/Script Files/BULK/BULK - BANKED MONTHS REPORT.vbs
@@ -567,7 +567,7 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 		END if
 		
 		report_date = MAXIS_footer_month & "/" & MAXIS_footer_year			'creating date variables to measure against person note counted dates
-			
+		 	
 		EMReadScreen wreg_total, 1, 2, 78
 		IF wreg_total <> "0" THEN
 			EmWriteScreen "x", 13, 57		'Pulls up the WREG tracker'
@@ -605,7 +605,18 @@ For item = 0 to UBound(Banked_Month_Client_Array, 2)		'Now each entry in the arr
 					
 					'reading to see if a month is counted month or not
 					EMReadScreen is_counted_month, 1, bene_yr_row, bene_mo_col
-					'counting and checking for counted ABAWD months
+					
+					'rejects cases that do not have the report month coded as a counted month
+					If report_date = abawd_counted_months_string then 
+						if is_counted_month <> "X" then 
+							if is_counted_month <> "M" then 
+								Banked_Month_Client_Array(send_to_DHS,     item) = FALSE	'Removing this client from DHS report - reason on next line'
+								Banked_Month_Client_Array(reason_excluded, item) = Banked_Month_Client_Array(reason_excluded, item) & "ABAWD tracking record not coded a counted ABAWD month (codes X or M) for " & report_date & ". Review manually. | "
+							END IF 
+						END IF 
+					END IF 	
+				
+					'counting and checking for counted ABAWD months	
 					IF is_counted_month = "X" or is_counted_month = "M" THEN
 						If abawd_counted_months_string <> report_date then
 							EMReadScreen counted_date_year, 2, bene_yr_row, 14			'reading counted year date


### PR DESCRIPTION
BLIP: Several enhancements to the script have been made. ABAWD month counting and filtering of banked months has been streamlined. All other updates are to add rejected cases to the rejected banked months list, along with the reason for rejection. Cases are now rejected for the following reasons:

Cases that can't access person notes
Cases that are coded 30/11
Cases that aren't coded as a 30/10
Cases that are prorated, but the approval is not prorated
Cases where the script cannot access the ABAWD tracking record
Cases where the report date is not coded as a counted ABAWD month on the ABAWD tracking record 
