### PR TITLE
Resolved #2487, Resolved #2498: EMPS panel and family cash navigation 

### DIFF
--- a/Script Files/NOTES/NOTES - CAF.vbs
+++ b/Script Files/NOTES/NOTES - CAF.vbs
@@ -57,13 +57,13 @@ BeginDialog case_number_dialog, 0, 0, 181, 120, "Case number dialog"
   Text 30, 85, 35, 10, "CAF type:"
 EndDialog
 
-BeginDialog CAF_dialog_01, 0, 0, 451, 260, "CAF dialog part 1"
+BeginDialog CAF_dialog_01, 0, 0, 451, 290, "CAF dialog part 1"
   EditBox 60, 5, 50, 15, CAF_datestamp
-  ComboBox 175, 5, 70, 15, " "+chr(9)+"phone"+chr(9)+"office", interview_type
+  ComboBox 175, 5, 70, 15, "phone"+chr(9)+"office", interview_type
   CheckBox 255, 5, 65, 10, "Used Interpreter", Used_Interpreter_checkbox
   EditBox 60, 25, 50, 15, interview_date
-  ComboBox 230, 25, 95, 15, " "+chr(9)+"in-person"+chr(9)+"dropped off"+chr(9)+"mailed in"+chr(9)+"ApplyMN"+chr(9)+"faxed"+chr(9)+"emailed", how_app_was_received
-  ComboBox 220, 45, 105, 15, " "+chr(9)+"DHS-2128 (LTC Renewal)"+chr(9)+"DHS-3417B (Req. to Apply...)"+chr(9)+"DHS-3418 (HC Renewal)"+chr(9)+"DHS-3531 (LTC Application)"+chr(9)+"DHS-3876 (Certain Pops App)"+chr(9)+"DHS-6696(MNsure HC App)", HC_document_received
+  ComboBox 230, 25, 95, 15, "in-person"+chr(9)+"dropped off"+chr(9)+"mailed in"+chr(9)+"ApplyMN"+chr(9)+"faxed"+chr(9)+"emailed", how_app_was_received
+  ComboBox 220, 45, 105, 15, "DHS-2128 (LTC Renewal)"+chr(9)+"DHS-3417B (Req. to Apply...)"+chr(9)+"DHS-3418 (HC Renewal)"+chr(9)+"DHS-3531 (LTC Application)"+chr(9)+"DHS-3876 (Certain Pops App)"+chr(9)+"DHS-6696(MNsure HC App)", HC_document_received
   EditBox 390, 45, 50, 15, HC_datestamp
   EditBox 75, 70, 370, 15, HH_comp
   EditBox 35, 90, 200, 15, cit_id
@@ -74,13 +74,16 @@ BeginDialog CAF_dialog_01, 0, 0, 451, 260, "CAF dialog part 1"
   EditBox 310, 130, 135, 15, FACI
   EditBox 35, 160, 410, 15, PREG
   EditBox 35, 180, 410, 15, ABPS
-  EditBox 55, 210, 390, 15, verifs_needed
+  EditBox 35, 200, 410, 15, EMPS
+  If worker_county_code = "x127" or worker_county_code = "x162" then CheckBox 35, 220, 180, 10, "Sent MFIP financial orientation DVD to participant(s).", MFIP_DVD_checkbox
+  'If worker_county_code = "x162" then CheckBox 35, 220, 180, 10, "Sent MFIP financial orientation DVD to participant(s).", MFIP_DVD_checkbox
+  EditBox 55, 235, 390, 15, verifs_needed
   ButtonGroup ButtonPressed
-    PushButton 340, 240, 50, 15, "NEXT", next_to_page_02_button
-    CancelButton 395, 240, 50, 15
+    PushButton 340, 270, 50, 15, "NEXT", next_to_page_02_button
+    CancelButton 395, 270, 50, 15
     PushButton 335, 15, 45, 10, "prev. panel", prev_panel_button
-    PushButton 335, 25, 45, 10, "next panel", next_panel_button
     PushButton 395, 15, 45, 10, "prev. memb", prev_memb_button
+    PushButton 335, 25, 45, 10, "next panel", next_panel_button
     PushButton 395, 25, 45, 10, "next memb", next_memb_button
     PushButton 5, 75, 60, 10, "HH comp/EATS:", EATS_button
     PushButton 240, 95, 20, 10, "IMIG:", IMIG_button
@@ -94,32 +97,31 @@ BeginDialog CAF_dialog_01, 0, 0, 451, 260, "CAF dialog part 1"
     PushButton 280, 135, 25, 10, "FACI:", FACI_button
     PushButton 5, 165, 25, 10, "PREG:", PREG_button
     PushButton 5, 185, 25, 10, "ABPS:", ABPS_button
-    PushButton 10, 240, 20, 10, "DWP", ELIG_DWP_button
-    PushButton 30, 240, 15, 10, "FS", ELIG_FS_button
-    PushButton 45, 240, 15, 10, "GA", ELIG_GA_button
-    PushButton 60, 240, 15, 10, "HC", ELIG_HC_button
-    PushButton 75, 240, 20, 10, "MFIP", ELIG_MFIP_button
-    PushButton 95, 240, 20, 10, "MSA", ELIG_MSA_button
-    PushButton 115, 240, 15, 10, "WB", ELIG_WB_button
-    PushButton 150, 240, 25, 10, "ADDR", ADDR_button
-    PushButton 175, 240, 25, 10, "MEMB", MEMB_button
-    PushButton 200, 240, 25, 10, "MEMI", MEMI_button
-    PushButton 225, 240, 25, 10, "PROG", PROG_button
-    PushButton 250, 240, 25, 10, "REVW", REVW_button
-    PushButton 275, 240, 25, 10, "TYPE", TYPE_button
-  Text 5, 10, 55, 10, "CAF datestamp:"
-  Text 120, 10, 50, 10, "Interview type:"
-  Text 5, 30, 55, 10, "Interview date:"
+    PushButton 5, 205, 25, 10, "EMPS", EMPS_button
+    PushButton 10, 270, 20, 10, "DWP", ELIG_DWP_button
+    PushButton 30, 270, 15, 10, "FS", ELIG_FS_button
+    PushButton 45, 270, 15, 10, "GA", ELIG_GA_button
+    PushButton 60, 270, 15, 10, "HC", ELIG_HC_button
+    PushButton 75, 270, 20, 10, "MFIP", ELIG_MFIP_button
+    PushButton 95, 270, 20, 10, "MSA", ELIG_MSA_button
+    PushButton 150, 270, 25, 10, "ADDR", ADDR_button
+    PushButton 175, 270, 25, 10, "MEMB", MEMB_button
+    PushButton 200, 270, 25, 10, "MEMI", MEMI_button
+    PushButton 225, 270, 25, 10, "PROG", PROG_button
+    PushButton 250, 270, 25, 10, "REVW", REVW_button
+    PushButton 275, 270, 25, 10, "TYPE", TYPE_button
   Text 120, 30, 110, 10, "How was application received?:"
   Text 5, 50, 210, 10, "If HC applied for (or recertifying): what document was received?:"
   Text 335, 50, 55, 10, "HC datestamp:"
   Text 5, 95, 25, 10, "CIT/ID:"
-  Text 5, 215, 50, 10, "Verifs needed:"
-  GroupBox 5, 230, 130, 25, "ELIG panels:"
-  GroupBox 145, 230, 160, 25, "other STAT panels:"
+  Text 5, 240, 50, 10, "Verifs needed:"
+  GroupBox 5, 260, 115, 25, "ELIG panels:"
+  GroupBox 145, 260, 160, 25, "other STAT panels:"
   GroupBox 330, 5, 115, 35, "STAT-based navigation"
+  Text 5, 10, 55, 10, "CAF datestamp:"
+  Text 5, 30, 55, 10, "Interview date:"
+  Text 120, 10, 50, 10, "Interview type:"
 EndDialog
-
 
 BeginDialog CAF_dialog_02, 0, 0, 451, 315, "CAF dialog part 2"
   EditBox 60, 45, 385, 15, earned_income
@@ -254,6 +256,7 @@ application_signed_checkbox = checked 'The script should default to having the a
 
 'GRABBING THE CASE NUMBER, THE MEMB NUMBERS, AND THE FOOTER MONTH------------------------------------------------------------------------------------------------------------------------------------------------
 EMConnect ""
+get_county_code				'since there is a county specific checkbox, this makes the the county clear
 Call MAXIS_case_number_finder(MAXIS_case_number)
 Call MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)
 
@@ -307,6 +310,7 @@ call autofill_editbox_from_MAXIS(HH_member_array, "COEX", COEX_DCEX)
 call autofill_editbox_from_MAXIS(HH_member_array, "DCEX", COEX_DCEX)
 call autofill_editbox_from_MAXIS(HH_member_array, "DIET", DIET)
 call autofill_editbox_from_MAXIS(HH_member_array, "DISA", DISA)
+call autofill_editbox_from_MAXIS(HH_member_array, "EMPS", EMPS)
 call autofill_editbox_from_MAXIS(HH_member_array, "FACI", FACI)
 call autofill_editbox_from_MAXIS(HH_member_array, "FMED", FMED)
 call autofill_editbox_from_MAXIS(HH_member_array, "IMIG", IMIG)
@@ -490,6 +494,8 @@ CALL write_bullet_and_variable_in_CASE_NOTE("FACI", FACI)
 CALL write_bullet_and_variable_in_CASE_NOTE("SCHL/STIN/STEC", SCHL)
 CALL write_bullet_and_variable_in_CASE_NOTE("DISA", DISA)
 CALL write_bullet_and_variable_in_CASE_NOTE("PREG", PREG)
+Call write_bullet_and_variable_in_CASE_NOTE("EMPS", EMPS)
+If MFIP_DVD_checkbox = 1 then Call write_variable_in_CASE_NOTE("* MFIP financial orientation DVD sent to participant(s).")
 CALL write_bullet_and_variable_in_CASE_NOTE("ABPS", ABPS)
 CALL write_bullet_and_variable_in_CASE_NOTE("Earned inc.", earned_income)
 CALL write_bullet_and_variable_in_CASE_NOTE("UNEA", unearned_income)

--- a/Script Files/NOTES/NOTES - CAF.vbs
+++ b/Script Files/NOTES/NOTES - CAF.vbs
@@ -76,7 +76,6 @@ BeginDialog CAF_dialog_01, 0, 0, 451, 290, "CAF dialog part 1"
   EditBox 35, 180, 410, 15, ABPS
   EditBox 35, 200, 410, 15, EMPS
   If worker_county_code = "x127" or worker_county_code = "x162" then CheckBox 35, 220, 180, 10, "Sent MFIP financial orientation DVD to participant(s).", MFIP_DVD_checkbox
-  'If worker_county_code = "x162" then CheckBox 35, 220, 180, 10, "Sent MFIP financial orientation DVD to participant(s).", MFIP_DVD_checkbox
   EditBox 55, 235, 390, 15, verifs_needed
   ButtonGroup ButtonPressed
     PushButton 340, 270, 50, 15, "NEXT", next_to_page_02_button
@@ -263,12 +262,15 @@ Call MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)
 'initial dialog
 Do
 	DO
+		err_msg = ""
 		Dialog case_number_dialog
 		cancel_confirmation
-		If CAF_type = "Select one..." Then MsgBox "You must select the CAF type."
-		If MAXIS_case_number = "" or IsNumeric(MAXIS_case_number) = False or len(MAXIS_case_number) > 8 then MsgBox "You need to type a valid case number."
-	Loop until CAF_type <> "Select one..."	
-Loop until MAXIS_case_number <> "" and IsNumeric(MAXIS_case_number) = True and len(MAXIS_case_number) <= 8
+		If CAF_type = "Select one..." then err_msg = err_msg & vbnewline & "* You must select the CAF type."
+		If MAXIS_case_number = "" or IsNumeric(MAXIS_case_number) = False or len(MAXIS_case_number) > 8 then err_msg = err_msg & vbnewline & "* You need to type a valid case number."
+		IF err_msg <> "" THEN MsgBox "*** NOTICE!!! ***" & vbNewLine & err_msg & vbNewLine		'error message including instruction on what needs to be fixed from each mandatory field if incorrect						
+	LOOP UNTIL err_msg = ""									'loops until all errors are resolved
+	CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS						
+Loop until are_we_passworded_out = false					'loops until user passwords back in					
 
 call check_for_MAXIS(False)	'checking for an active MAXIS session
 MAXIS_footer_month_confirmation	'function will check the MAXIS panel footer month/year vs. the footer month/year in the dialog, and will navigate to the dialog month/year if they do not match.

--- a/Script Files/NOTES/NOTES - CAF.vbs
+++ b/Script Files/NOTES/NOTES - CAF.vbs
@@ -59,11 +59,11 @@ EndDialog
 
 BeginDialog CAF_dialog_01, 0, 0, 451, 290, "CAF dialog part 1"
   EditBox 60, 5, 50, 15, CAF_datestamp
-  ComboBox 175, 5, 70, 15, "phone"+chr(9)+"office", interview_type
+  ComboBox 175, 5, 70, 15, " "+chr(9)+"phone"+chr(9)+"office", interview_type
   CheckBox 255, 5, 65, 10, "Used Interpreter", Used_Interpreter_checkbox
   EditBox 60, 25, 50, 15, interview_date
-  ComboBox 230, 25, 95, 15, "in-person"+chr(9)+"dropped off"+chr(9)+"mailed in"+chr(9)+"ApplyMN"+chr(9)+"faxed"+chr(9)+"emailed", how_app_was_received
-  ComboBox 220, 45, 105, 15, "DHS-2128 (LTC Renewal)"+chr(9)+"DHS-3417B (Req. to Apply...)"+chr(9)+"DHS-3418 (HC Renewal)"+chr(9)+"DHS-3531 (LTC Application)"+chr(9)+"DHS-3876 (Certain Pops App)"+chr(9)+"DHS-6696(MNsure HC App)", HC_document_received
+  ComboBox 230, 25, 95, 15, " "+chr(9)+"in-person"+chr(9)+"dropped off"+chr(9)+"mailed in"+chr(9)+"ApplyMN"+chr(9)+"faxed"+chr(9)+"emailed", how_app_was_received
+  ComboBox 220, 45, 105, 15, " "+chr(9)+"DHS-2128 (LTC Renewal)"+chr(9)+"DHS-3417B (Req. to Apply...)"+chr(9)+"DHS-3418 (HC Renewal)"+chr(9)+"DHS-3531 (LTC Application)"+chr(9)+"DHS-3876 (Certain Pops App)"+chr(9)+"DHS-6696(MNsure HC App)", HC_document_received
   EditBox 390, 45, 50, 15, HC_datestamp
   EditBox 75, 70, 370, 15, HH_comp
   EditBox 35, 90, 200, 15, cit_id

--- a/Script Files/NOTES/NOTES - CAF.vbs
+++ b/Script Files/NOTES/NOTES - CAF.vbs
@@ -103,23 +103,25 @@ BeginDialog CAF_dialog_01, 0, 0, 451, 290, "CAF dialog part 1"
     PushButton 60, 270, 15, 10, "HC", ELIG_HC_button
     PushButton 75, 270, 20, 10, "MFIP", ELIG_MFIP_button
     PushButton 95, 270, 20, 10, "MSA", ELIG_MSA_button
-    PushButton 150, 270, 25, 10, "ADDR", ADDR_button
-    PushButton 175, 270, 25, 10, "MEMB", MEMB_button
-    PushButton 200, 270, 25, 10, "MEMI", MEMI_button
-    PushButton 225, 270, 25, 10, "PROG", PROG_button
-    PushButton 250, 270, 25, 10, "REVW", REVW_button
-    PushButton 275, 270, 25, 10, "TYPE", TYPE_button
-  Text 120, 30, 110, 10, "How was application received?:"
-  Text 5, 50, 210, 10, "If HC applied for (or recertifying): what document was received?:"
+    PushButton 130, 270, 25, 10, "ADDR", ADDR_button
+    PushButton 155, 270, 25, 10, "MEMB", MEMB_button
+    PushButton 180, 270, 25, 10, "MEMI", MEMI_button
+    PushButton 205, 270, 25, 10, "PROG", PROG_button
+    PushButton 230, 270, 25, 10, "REVW", REVW_button
+    PushButton 255, 270, 25, 10, "SANC", SANC_button
+    PushButton 280, 270, 25, 10, "TIME", TIME_button
+    PushButton 305, 270, 25, 10, "TYPE", TYPE_button
   Text 335, 50, 55, 10, "HC datestamp:"
   Text 5, 95, 25, 10, "CIT/ID:"
   Text 5, 240, 50, 10, "Verifs needed:"
   GroupBox 5, 260, 115, 25, "ELIG panels:"
-  GroupBox 145, 260, 160, 25, "other STAT panels:"
+  GroupBox 125, 260, 210, 25, "other STAT panels:"
   GroupBox 330, 5, 115, 35, "STAT-based navigation"
   Text 5, 10, 55, 10, "CAF datestamp:"
   Text 5, 30, 55, 10, "Interview date:"
   Text 120, 10, 50, 10, "Interview type:"
+  Text 5, 50, 210, 10, "If HC applied for (or recertifying): what document was received?:"
+  Text 120, 30, 110, 10, "How was application received?:"
 EndDialog
 
 BeginDialog CAF_dialog_02, 0, 0, 451, 315, "CAF dialog part 2"

--- a/Script Files/NOTES/NOTES - HRF.vbs
+++ b/Script Files/NOTES/NOTES - HRF.vbs
@@ -38,12 +38,9 @@ IF IsEmpty(FuncLib_URL) = TRUE THEN	'Shouldn't load FuncLib if it already loaded
 END IF
 'END FUNCTIONS LIBRARY BLOCK================================================================================================
 
-'DATE CALCULATIONS----------------------------------------------------------------------------------------------------
-next_month = dateadd("m", + 1, date)
-MAXIS_footer_month = datepart("m", next_month)
-If len(MAXIS_footer_month) = 1 then MAXIS_footer_month = "0" & MAXIS_footer_month
-MAXIS_footer_year = datepart("yyyy", next_month)
-MAXIS_footer_year = "" & MAXIS_footer_year - 2000
+'defaulting the MAXIS footer month/year to current month plus one
+MAXIS_footer_month = CM_plus_1_mo
+MAXIS_footer_year = CM_plus_1_yr
 
 'DIALOGS-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 BeginDialog case_number_dialog, 0, 0, 181, 100, "Case number dialog"
@@ -124,7 +121,6 @@ BeginDialog HRF_dialog, 0, 0, 451, 250, "HRF dialog"
   Text 130, 95, 35, 10, "Changes?:"
 EndDialog
 
-
 BeginDialog case_note_dialog, 0, 0, 136, 51, "Case note dialog"
   ButtonGroup ButtonPressed
     PushButton 15, 20, 105, 10, "Yes, take me to case note.", yes_case_note_button
@@ -145,11 +141,14 @@ EMConnect ""
 call MAXIS_case_number_finder(MAXIS_case_number)
 
 'Showing case number dialog
-Do
-  Dialog case_number_dialog
-  cancel_confirmation
-  If MAXIS_case_number = "" or IsNumeric(MAXIS_case_number) = False or len(MAXIS_case_number) > 8 then MsgBox "You need to type a valid case number."
-Loop until MAXIS_case_number <> "" and IsNumeric(MAXIS_case_number) = True and len(MAXIS_case_number) <= 8
+do 
+	Do
+  		Dialog case_number_dialog
+  		cancel_confirmation
+  		If MAXIS_case_number = "" or IsNumeric(MAXIS_case_number) = False or len(MAXIS_case_number) > 8 then MsgBox "You need to type a valid case number."
+	Loop until MAXIS_case_number <> "" and IsNumeric(MAXIS_case_number) = True and len(MAXIS_case_number) <= 8
+	CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS						
+Loop until are_we_passworded_out = false					'loops until user passwords back in					
 
 'Checking for an active MAXIS seesion
 Call check_for_MAXIS(False)
@@ -233,8 +232,6 @@ If grab_GA_info_check = 1 Then
 		END If
 END IF
 
-
-
 'Creating program list---------------------------------------------------------------------------------------------
 If MFIP_check = 1 Then programs_list = "MFIP "
 If SNAP_check = 1 Then programs_list = programs_list & "SNAP "
@@ -274,4 +271,4 @@ If GAPR_check = "GAPR" Then
 End If
 call write_variable_in_CASE_NOTE(worker_signature)
 
-call script_end_procedure("")
+script_end_procedure("")

--- a/Script Files/NOTES/NOTES - HRF.vbs
+++ b/Script Files/NOTES/NOTES - HRF.vbs
@@ -60,27 +60,28 @@ BeginDialog case_number_dialog, 0, 0, 181, 100, "Case number dialog"
   GroupBox 5, 45, 170, 30, "Programs recertifying"
 EndDialog
 
-BeginDialog HRF_dialog, 0, 0, 451, 250, "HRF dialog"
+BeginDialog HRF_dialog, 0, 0, 451, 270, "HRF dialog"
   EditBox 65, 30, 50, 15, HRF_datestamp
-  DropListBox 170, 30, 75, 15, " " +chr(9)+"complete"+chr(9)+"incomplete", HRF_status
+  DropListBox 170, 30, 75, 15, " "+chr(9)+"complete"+chr(9)+"incomplete", HRF_status
   EditBox 65, 50, 380, 15, earned_income
   EditBox 70, 70, 375, 15, unearned_income
   EditBox 30, 90, 90, 15, YTD
   EditBox 170, 90, 275, 15, changes
-  EditBox 100, 110, 345, 15, FIAT_reasons
-  EditBox 50, 130, 395, 15, other_notes
-  CheckBox 190, 150, 60, 10, "10% sanction?", ten_percent_sanction_check
-  CheckBox 265, 150, 60, 10, "30% sanction?", thirty_percent_sanction_check
-  CheckBox 330, 150, 85, 10, "Sent forms to AREP?", sent_arep_checkbox
-  EditBox 240, 165, 205, 15, verifs_needed
-  EditBox 235, 185, 210, 15, actions_taken
-  CheckBox 125, 205, 180, 10, "Check here to case note grant info from ELIG/MFIP.", grab_MFIP_info_check
-  CheckBox 125, 220, 170, 10, "Check here to case note grant info from ELIG/FS. ", grab_FS_info_check
-  CheckBox 125, 235, 170, 10, "Check here to case note grant info from ELIG/GA.", grab_GA_info_check
-  EditBox 380, 205, 65, 15, worker_signature
+  EditBox 30, 110, 415, 15, EMPS
+  EditBox 100, 130, 345, 15, FIAT_reasons
+  EditBox 50, 150, 395, 15, other_notes
+  CheckBox 190, 170, 60, 10, "10% sanction?", ten_percent_sanction_check
+  CheckBox 265, 170, 60, 10, "30% sanction?", thirty_percent_sanction_check
+  CheckBox 330, 170, 85, 10, "Sent forms to AREP?", sent_arep_checkbox
+  EditBox 235, 185, 210, 15, verifs_needed
+  EditBox 235, 205, 210, 15, actions_taken
+  CheckBox 100, 225, 175, 10, "Check here to case note grant info from ELIG/MFIP.", grab_MFIP_info_check
+  CheckBox 100, 240, 170, 10, "Check here to case note grant info from ELIG/FS. ", grab_FS_info_check
+  CheckBox 100, 255, 170, 10, "Check here to case note grant info from ELIG/GA.", grab_GA_info_check
+  EditBox 340, 225, 105, 15, worker_signature
   ButtonGroup ButtonPressed
-    OkButton 340, 225, 50, 15
-    CancelButton 395, 225, 50, 15
+    OkButton 340, 245, 50, 15
+    CancelButton 395, 245, 50, 15
     PushButton 260, 20, 20, 10, "FS", ELIG_FS_button
     PushButton 280, 20, 20, 10, "HC", ELIG_HC_button
     PushButton 300, 20, 20, 10, "MFIP", ELIG_MFIP_button
@@ -89,36 +90,40 @@ BeginDialog HRF_dialog, 0, 0, 451, 250, "HRF dialog"
     PushButton 395, 20, 45, 10, "prev. memb", prev_memb_button
     PushButton 335, 30, 45, 10, "next panel", next_panel_button
     PushButton 395, 30, 45, 10, "next memb", next_memb_button
-    PushButton 10, 165, 25, 10, "BUSI", BUSI_button
-    PushButton 35, 165, 25, 10, "JOBS", JOBS_button
-    PushButton 75, 165, 25, 10, "ACCT", ACCT_button
-    PushButton 100, 165, 25, 10, "CARS", CARS_button
-    PushButton 125, 165, 25, 10, "CASH", CASH_button
-    PushButton 150, 165, 25, 10, "OTHR", OTHR_button
-    PushButton 10, 175, 25, 10, "RBIC", RBIC_button
-    PushButton 35, 175, 25, 10, "UNEA", UNEA_button
-    PushButton 75, 175, 25, 10, "REST", REST_button
-    PushButton 100, 175, 25, 10, "SECU", SECU_button
-    PushButton 125, 175, 25, 10, "TRAN", TRAN_button
-    PushButton 10, 210, 25, 10, "MEMB", MEMB_button
-    PushButton 35, 210, 25, 10, "MEMI", MEMI_button
-    PushButton 60, 210, 25, 10, "MONT", MONT_button
-  GroupBox 255, 5, 70, 40, "ELIG panels:"
+    PushButton 5, 115, 25, 10, "EMPS", EMPS_button
+    PushButton 10, 185, 25, 10, "BUSI", BUSI_button
+    PushButton 35, 185, 25, 10, "JOBS", JOBS_button
+    PushButton 10, 195, 25, 10, "RBIC", RBIC_button
+    PushButton 35, 195, 25, 10, "UNEA", UNEA_button
+    PushButton 75, 185, 25, 10, "ACCT", ACCT_button
+    PushButton 100, 185, 25, 10, "CARS", CARS_button
+    PushButton 125, 185, 25, 10, "CASH", CASH_button
+    PushButton 150, 185, 25, 10, "OTHR", OTHR_button
+    PushButton 75, 195, 25, 10, "REST", REST_button
+    PushButton 100, 195, 25, 10, "SECU", SECU_button
+    PushButton 125, 195, 25, 10, "TRAN", TRAN_button
+    PushButton 10, 230, 25, 10, "MEMB", MEMB_button
+    PushButton 35, 230, 25, 10, "MEMI", MEMI_button
+    PushButton 60, 230, 25, 10, "MONT", MONT_button
+    PushButton 10, 240, 25, 10, "PARE", PARE_button
+    PushButton 35, 240, 25, 10, "SANC", SANC_button
+    PushButton 60, 240, 25, 10, "TIME", TIME_button
+  Text 5, 95, 20, 10, "YTD:"
+  Text 5, 135, 95, 10, "FIAT reasons (if applicable):"
+  Text 5, 155, 45, 10, "Other notes:"
+  GroupBox 5, 170, 60, 40, "Income panels"
+  GroupBox 70, 170, 110, 40, "Asset panels"
+  Text 280, 230, 60, 10, "Worker signature:"
+  Text 185, 210, 50, 10, "Actions taken:"
+  GroupBox 5, 215, 85, 40, "other STAT panels:"
+  Text 185, 190, 50, 10, "Verifs needed:"
+  Text 125, 35, 40, 10, "HRF status:"
+  Text 130, 95, 35, 10, "Changes?:"
   GroupBox 330, 5, 115, 40, "STAT-based navigation"
   Text 5, 35, 55, 10, "HRF datestamp:"
   Text 5, 55, 55, 10, "Earned income:"
   Text 5, 75, 60, 10, "Unearned income:"
-  Text 5, 95, 20, 10, "YTD:"
-  Text 5, 115, 95, 10, "FIAT reasons (if applicable):"
-  Text 5, 135, 45, 10, "Other notes:"
-  GroupBox 5, 150, 60, 40, "Income panels"
-  GroupBox 70, 150, 110, 40, "Asset panels"
-  Text 315, 210, 65, 10, "Worker signature:"
-  Text 185, 190, 50, 10, "Actions taken:"
-  GroupBox 5, 195, 85, 30, "other STAT panels:"
-  Text 185, 170, 50, 10, "Verifs needed:"
-  Text 125, 35, 40, 10, "HRF status:"
-  Text 130, 95, 35, 10, "Changes?:"
+  GroupBox 255, 5, 70, 40, "ELIG panels:"
 EndDialog
 
 BeginDialog case_note_dialog, 0, 0, 136, 51, "Case note dialog"
@@ -161,6 +166,7 @@ call HH_member_custom_dialog(HH_member_array)
 
 'Autofilling info for case note
 call autofill_editbox_from_MAXIS(HH_member_array, "BUSI", earned_income)
+call autofill_editbox_from_MAXIS(HH_member_array, "EMPS", EMPS)
 call autofill_editbox_from_MAXIS(HH_member_array, "JOBS", earned_income)
 call autofill_editbox_from_MAXIS(HH_member_array, "MONT", HRF_datestamp)
 call autofill_editbox_from_MAXIS(HH_member_array, "RBIC", earned_income)
@@ -246,6 +252,7 @@ call write_bullet_and_variable_in_case_note("Earned income", earned_income)
 call write_bullet_and_variable_in_case_note("Unearned income", unearned_income)
 call write_bullet_and_variable_in_case_note("YTD", YTD)
 call write_bullet_and_variable_in_case_note("Changes", changes)
+call write_bullet_and_variable_in_case_note("EMPS", EMPS)
 call write_bullet_and_variable_in_case_note("FIAT reasons", FIAT_reasons)
 call write_bullet_and_variable_in_case_note("Other notes", other_notes)
 If ten_percent_sanction_check = 1 then call write_variable_in_CASE_NOTE("* 10% sanction.")


### PR DESCRIPTION
CAF BLIP: Added EMPS panel field to the CAF 1 dialog. This field will be auto-filled with the information for all HH members on the case. Also added EMPS, SANC and TIME navigation buttons, removed the WB ELIG navigation and updated the password check handling on the back end. 
For Hennepin County and Ramsey County workers: a checkbox has been added "Sent MFIP financial orientation DVD to participant(s)." This check box will case note if a participant has been given a financial orientation DVD."

HRF BLIP: Added EMPS panel field to the main dialog. This field will be auto-filled with the information for all HH members on the case. Also added EMPS, SANC and TIME navigation buttons, update dates to global constants and updated the password check handling on the back end. 
 