### PR TITLE
RESOLVES #2497 Adding newly exempt counties

### DIFF
--- a/Script Files/ACTIONS/ACTIONS - ABAWD BANKED MONTHS FIATER.vbs
+++ b/Script Files/ACTIONS/ACTIONS - ABAWD BANKED MONTHS FIATER.vbs
@@ -113,7 +113,6 @@ call check_for_maxis(false)
 call maxis_case_number_finder(MAXIS_case_number)
 
 If worker_county_code = "x101" OR _
-		worker_county_code = "x101" OR _
 		worker_county_code = "x111" OR _
 		worker_county_code = "x115" OR _
 		worker_county_code = "x129" OR _

--- a/Script Files/ACTIONS/ACTIONS - ABAWD BANKED MONTHS FIATER.vbs
+++ b/Script Files/ACTIONS/ACTIONS - ABAWD BANKED MONTHS FIATER.vbs
@@ -113,12 +113,19 @@ call check_for_maxis(false)
 call maxis_case_number_finder(MAXIS_case_number)
 
 If worker_county_code = "x101" OR _
+		worker_county_code = "x101" OR _
+		worker_county_code = "x111" OR _
 		worker_county_code = "x115" OR _
 		worker_county_code = "x129" OR _
+		worker_county_code = "x131" OR _
 		worker_county_code = "x133" OR _
 		worker_county_code = "x136" OR _
 		worker_county_code = "x139" OR _
-		worker_county_code = "x144" THEN
+		worker_county_code = "x144" OR_
+		worker_county_code = "x145" OR _
+		worker_county_code = "x148" OR _
+		worker_county_code = "x154" OR _
+		worker_county_code = "x180" THEN
 		script_end_procedure ("Your agency is exempt from ABAWD work requirements. SNAP banked months are not available to your recipients.")
 END IF
 

--- a/Script Files/NOTICES/NOTICES - SNAP E AND T LETTER.vbs
+++ b/Script Files/NOTICES/NOTICES - SNAP E AND T LETTER.vbs
@@ -252,12 +252,18 @@ DO
 		err_msg = ""
 		'these counties are exempt from participation per the FNS'
 		If worker_county_code = "x101" OR _
+			worker_county_code = "x111" OR _
 			worker_county_code = "x115" OR _
 			worker_county_code = "x129" OR _
+			worker_county_code = "x131" OR _
 			worker_county_code = "x133" OR _
 			worker_county_code = "x136" OR _
 			worker_county_code = "x139" OR _
-			worker_county_code = "x144" THEN
+			worker_county_code = "x144" OR_
+			worker_county_code = "x145" OR _
+			worker_county_code = "x148" OR _
+			worker_county_code = "x154" OR _
+			worker_county_code = "x180" THEN
 			script_end_procedure ("Your agency is exempt from ABAWD work requirements through 09/30/16." & vbNewLine & vbNewLine & " Please refer to TE02.05.69 for reference.")
 		ElseIF worker_county_code = "x127" THEN
 			Dialog SNAPET_Hennepin_dialog


### PR DESCRIPTION
BLIP: Added safeguard to disallow counties who are exempt from ABAWD work requirements to use this script.

(changing to a problem as in 7 days it becomes one)