### PR TITLE
Resolves #2666 New CS Scrubber stuck in loop on MFIP / SNAP cases

### DIFF
--- a/Script Files/DAIL/DAIL - CSES SCRUBBER.vbs
+++ b/Script Files/DAIL/DAIL - CSES SCRUBBER.vbs
@@ -1171,7 +1171,7 @@ IF SNAP_active = TRUE Then
 	Dim xlBook 
 	Dim xlSheet 
 	RowCN = 1
-	Set objSheet = objExcel.ActiveWorkbook.Worksheets(1) 
+	Set objSheet = objExcel.ActiveWorkbook.Worksheets("SNAP Budget") 
 	Do
 		MEMBandTYPE = Trim(objSheet.Cells(RowCN, 1).Value)
 		Do


### PR DESCRIPTION
Blip: This resolves an error that was causing the script to be stuck in a loop while trying to note certain SNAP / MFIP combined household cases.