### PR TITLE
Resolved #2700, MFIP sanction 10 day bug in release

### DIFF
--- a/Script Files/NOTES/NOTES - MFIP SANCTION AND DWP DISQUALIFICATION.vbs
+++ b/Script Files/NOTES/NOTES - MFIP SANCTION AND DWP DISQUALIFICATION.vbs
@@ -200,11 +200,6 @@ If action_type = "Apply sanction/disq."	then
 		LOOP UNTIL err_msg = ""
 		CALL check_for_password(are_we_passworded_out)			'function that checks to ensure that the user has not passworded out of MAXIS, allows user to password back into MAXIS						
 	Loop until are_we_passworded_out = false					'loops until user passwords back in					
-
-    'creating variabels for sanction date month and sanction date year to use in ten_day_cut_off function
-	sanction_month =  right("0" &          	 DatePart("m",           DateAdd("m", -1, Date_Sanction)            ), 2)
-	sanction_year  =  right(                 DatePart("yyyy",        DateAdd("m", -1, Date_Sanction)            ), 2)
-	call ten_day_cutoff_check(sanction_month, sanction_year, ten_day_cutoff)
 	
 	'TIKL to change sanction status (check box selected)
 	If TIKL_next_month = checked THEN 
@@ -231,7 +226,7 @@ If action_type = "Apply sanction/disq."	then
 	ELSEIf (sanction_type_droplist = "CS") then
 		Resolution_date = DateAdd("d", -1, Date_Sanction)
 	ELSE
-		Resolution_date = ten_day_cutoff
+		Resolution_date = DateAdd("d", -10, Date_Sanction)
 	End If
 	
 	'case noting the droplist and editboxes


### PR DESCRIPTION
BLIP: Updated non-CS sanction and non-consecutive month sanction's resolved date to be 10 days prior to the end of the month.