### PR TITLE
Resolves #2738 CSES processing Bug

### DIFF
--- a/Script Files/DAIL/DAIL - CSES SCRUBBER.vbs
+++ b/Script Files/DAIL/DAIL - CSES SCRUBBER.vbs
@@ -548,6 +548,7 @@ If SNAP_active = TRUE Then
 	transmit
 
 	EMReadScreen FPG_130, 8, 8, 73
+	If FPG_130 = "        " THEN FPG_130 = "9999"
 	transmit
 	EMReadScreen REPT_status, 9, 8, 31
 	amount_CS_reported = 0


### PR DESCRIPTION
Fixes a bug that caused the script to error when seeking information from cases with an ineligible SNAP version approved.