### PR TITLE
RE: #2710 Correcting error in Check SNAP for GA RCA

### DIFF
--- a/bulk/check-snap-for-ga-rca.vbs
+++ b/bulk/check-snap-for-ga-rca.vbs
@@ -44,7 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
-call changelog_update("11/28/2016", "Added safety functionality for if MAXIS is passworded out."m "Casey Love, Ramsey County")
+call changelog_update("11/28/2016", "Added safety functionality for if MAXIS is passworded out.", "Casey Love, Ramsey County")
 call changelog_update("11/28/2016", "Initial version.", "Charles Potter, DHS")
 
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.


### PR DESCRIPTION
BLIP: This update to the script corrects a typo that was preventing the script from running.