### PR TITLE
#2915, #2954, #2897, #2934, #2948 NOTICES/NOTES issue

### DIFF
--- a/notes/emergency.vbs
+++ b/notes/emergency.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("03/02/2018", "Fixed header for case notes that have an EGA screening, header information was duplicating.", "Ilse Ferris, Hennepin County")
 call changelog_update("11/28/2016", "Initial version.", "Charles Potter, DHS")
 
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.

--- a/notes/emergency.vbs
+++ b/notes/emergency.vbs
@@ -284,6 +284,7 @@ If EGA_screening_check = 1 then
     	EMER_available_date = "Currently available"
     END IF
 
+	crisis = ""
     'Logic to enter what the "crisis" variable is from the check boxes indicated
     If eviction_check = 1 then crisis = crisis & "eviction, "
     If utility_disconnect_check = 1 then crisis = crisis & "utility disconnect, "
@@ -431,6 +432,7 @@ DO
 	 call check_for_password(are_we_passworded_out)  'Adding functionality for MAXIS v.6 Passworded Out issue'
  LOOP UNTIL are_we_passworded_out = false
 
+crisis = ""
 'Logic to enter what the "crisis" variable is from the checkboxes indicated
 If eviction_check = 1 then crisis = crisis & "eviction, "
 If utility_disconnect_check = 1 then crisis = crisis & "utility disconnect, "

--- a/notes/interview-completed.vbs
+++ b/notes/interview-completed.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("03/01/2018", "Updated to allow for cases that do not have CAF date listed on STAT/REVW.", "Ilse Ferris, Hennepin County")
 call changelog_update("11/28/2016", "Initial version.", "Charles Potter, DHS")
 
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.

--- a/notes/ltc-cola-summary.vbs
+++ b/notes/ltc-cola-summary.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("11/29/2016", "Updated header of case note for eligibility to reflect the MAXIS footer month, not a static month of '01'.", "Ilse Ferris, Hennepin County")
 call changelog_update("11/29/2016", "Added header update for 2017 in case notes, and made this a variable year vs. hard coding this information into the script, and needing yearly updates.", "Ilse Ferris, Hennepin County")
 call changelog_update("11/28/2016", "Initial version.", "Charles Potter, DHS")
 
@@ -333,7 +334,7 @@ EndDialog
   EMWriteScreen MAXIS_case_number, 18, 43
 
   Call start_a_blank_CASE_NOTE
-  EMSendKey "**Approved COLA updates 01/" & MAXIS_footer_year & ": " & elig_type & "-" & budget_type & " " & recipient_amt
+  EMSendKey "**Approved COLA updates for " & MAXIS_footer_month & "/" & MAXIS_footer_year & ": " & elig_type & "-" & budget_type & " " & recipient_amt
   If budget_type = "L" then EMSendKey " LTC SD**"
   If budget_type = "S" then EMSendKey " SISEW waiver obl**"
   If budget_type = "B" then EMSendKey " Recip amt.**"

--- a/notes/ltc-intake-approval.vbs
+++ b/notes/ltc-intake-approval.vbs
@@ -44,6 +44,7 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+call changelog_update("03/02/2018", "Resolved bug that was running through MAXIS panels when user selected to 'cancel' the script.", "Ilse Ferris, Hennepin County")
 call changelog_update("11/28/2016", "Initial version.", "Charles Potter, DHS")
 
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.
@@ -476,8 +477,8 @@ Do
 	Do
 		Do
 			Dialog intake_approval_dialog
+            cancel_confirmation
 			MAXIS_dialog_navigation
-			cancel_confirmation
 			'ensures that baseline date is in full date format so that the 'lookback period' is calculated correctly
 			IF len(baseline_date) < 10 THEN MsgBox "You must enter the baseline date in format MM/DD/YYYY"
 		LOOP until len(baseline_date) >= 10

--- a/notices/ltc-asset-transfer.vbs
+++ b/notices/ltc-asset-transfer.vbs
@@ -44,38 +44,40 @@ changelog = array()
 
 'INSERT ACTUAL CHANGES HERE, WITH PARAMETERS DATE, DESCRIPTION, AND SCRIPTWRITER. **ENSURE THE MOST RECENT CHANGE GOES ON TOP!!**
 'Example: call changelog_update("01/01/2000", "The script has been updated to fix a typo on the initial dialog.", "Jane Public, Oak County")
+CALL changelog_update("03/01/2018", "Added sending SPEC/MEMO functionality, and does not require the user to navigate to SPEC/MEMO before using the script.", "Ilse Ferris, Hennepin County")
 call changelog_update("11/28/2016", "Initial version.", "Charles Potter, DHS")
 
 'Actually displays the changelog. This function uses a text file located in the My Documents folder. It stores the name of the script file and a description of the most recent viewed change.
 changelog_display
 'END CHANGELOG BLOCK =======================================================================================================
 
-BeginDialog LTC_asset_transfer_dialog, 0, 0, 126, 82, "LTC asset transfer dialog"
-  EditBox 35, 0, 85, 15, client
-  EditBox 35, 20, 85, 15, spouse
-  EditBox 70, 40, 50, 15, renewal_footer_month_year
+BeginDialog LTC_asset_transfer_dialog, 0, 0, 126, 110, "LTC asset transfer dialog"
+  EditBox 60, 5, 60, 15, MAXIS_case_number
+  EditBox 35, 30, 85, 15, client
+  EditBox 35, 50, 85, 15, spouse
+  EditBox 70, 70, 50, 15, renewal_footer_month_year
   ButtonGroup LTC_asset_transfer_dialog_ButtonPressed
-    OkButton 10, 60, 50, 15
-    CancelButton 65, 60, 50, 15
-  Text 5, 5, 30, 10, "Client:"
-  Text 5, 25, 30, 10, "Spouse:"
-  Text 5, 45, 65, 10, "ER date (MM/YY):"
+    OkButton 10, 90, 50, 15
+    CancelButton 65, 90, 50, 15
+  Text 5, 55, 30, 10, "Spouse:"
+  Text 5, 75, 65, 10, "ER date (MM/YY):"
+  Text 5, 35, 30, 10, "Client:"
+  Text 5, 10, 45, 10, "Case number:"
 EndDialog
 
 'The script------------------------
 'connecting to MAXIS
 EMConnect ""
+Call MAXIS_case_number_finder(MAXIS_case_number)
+
 Do
   Dialog LTC_asset_transfer_dialog
   If LTC_asset_transfer_dialog_ButtonPressed = 0 then stopscript
-  EMSendKey "<enter>"
-  EMWaitReady 1, 1
-  EMReadScreen WCOM_input_check, 27, 2, 28
-  If WCOM_input_check <> "Worker Comment Input Screen" and WCOM_input_check <> "  Client Memo Input Screen " then MsgBox "You need to be on a notice in SPEC/WCOM or SPEC/MEMO for this to work. Please try again."
-Loop until WCOM_input_check = "Worker Comment Input Screen" or WCOM_input_check = "  Client Memo Input Screen "
+  call check_for_password(are_we_passworded_out)  'Adding functionality for MAXIS v.6 Passworded Out issue'
+LOOP UNTIL are_we_passworded_out = false
+ 
+Call start_a_new_spec_memo	'navigates to spec/memo and opens into edit mode 
+Call write_variable_in_SPEC_MEMO("The ownership of " & spouse & " to avoid having them counted in future eligibility determinations. You are encouraged to do this as soon as possible. This transfer of assets must be done before " & client & "'s first annual renewal for " & renewal_footer_month_year & ". Verification of the transfer can be provided at any time.")
+Call write_variable_in_SPEC_MEMO("At the first annual renewal in " & renewal_footer_month_year & " the value of all assets that list " & client & " as an owner or co-owner will be applied towards the Medical Assistance Asset limit of $3,000.00.  If the total value of all countable assets for " & client & " is more than $3,000.00, Medical Assistance may be closed for " & renewal_footer_month_year & ".")
 
-EMSendKey "<home>" + "The ownership of " + client + "'s assets must be transferred to " + spouse + " to avoid having them counted in future eligibility determinations. You are encouraged to do this as soon as possible. This transfer of assets must be done before " + client + "'s first annual renewal for " + renewal_footer_month_year + ". Verification of the transfer can be provided at any time. " + "<newline>" + "<newline>"
-EMSendKey "At the first annual renewal in " + renewal_footer_month_year + " the value of all assets that list " + client + " as an owner or co-owner will be applied towards the Medical Assistance Asset limit of $3,000.00.  If the total value of all countable assets for " + client + " is more than $3,000.00, Medical Assistance may be closed for " + renewal_footer_month_year + "."
-
-script_end_procedure("")
-NOTICES
+script_end_procedure("Please review your notice before pressing PF4 to send.")


### PR DESCRIPTION
#2915 NOTES INTERVIEW COMPLETED: updated to allow to use in CM + 2
#2954 NOTICES - LTC Asset transfer: updated SPEC/MEMO function
#2897 NOTES - EMERGENCY: resetting crisis variable to prevent duplicate header
#2934 NOTES - LTC COLA SUMMARY: updated case note header to read MAXIS footer month
#2948 NOTES - LTC INTAKE APPROVAL: moved cancel confirmation
